### PR TITLE
LIBITD-1894. Initial VS Code "Remote Containers" configuration

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,14 @@
+{
+  "name": "umd-drupal",
+  "service": "php",
+  "dockerComposeFile": [
+    "../docker-compose.yml"
+  ],
+	"extensions": [
+		"felixfbecker.php-debug",
+		"felixfbecker.php-intellisense",
+    "ikappas.phpcs"
+	],
+	"shutdownAction": "none",
+	"workspaceFolder": "/var/www/html"
+}

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,14 @@
+{
+  // Use IntelliSense to learn about possible attributes.
+  // Hover to view descriptions of existing attributes.
+  // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+  "version": "0.2.0",
+  "configurations": [
+    {
+      "name": "Listen for Xdebug",
+      "type": "php",
+      "request": "launch",
+      "port": 9123
+    }
+  ]
+}

--- a/README.md
+++ b/README.md
@@ -256,3 +256,20 @@ To create a local Solr core with through docker-compose, do the following:
 
            > docker exec [container]_postgres pg_dump -U drupaluser -O drupaldb > /tmp/dump.sql
 
+## Tools
+
+### PHP CodeSniffer
+
+PHP CodeSniffer (https://github.com/squizlabs/PHP_CodeSniffer) is a linter for
+identifying coding standard violations.
+
+The current configuration is defined in the "phpcs.xml.dist" file.
+
+To check a particular directory or file, run the following commands:
+
+            > vendor/bin/phpcs <DIRECTORY_OR_FILE>
+            
+where <DIRECTORY_OR_FILE> is the name of the directory or file. For example,
+to check the code in the "web/modules/custom/" directory, run:
+
+            > vendor/bin/phpcs web/modules/custom/

--- a/README.md
+++ b/README.md
@@ -273,3 +273,140 @@ where <DIRECTORY_OR_FILE> is the name of the directory or file. For example,
 to check the code in the "web/modules/custom/" directory, run:
 
             > vendor/bin/phpcs web/modules/custom/
+
+## VS Code Remote Containers
+
+The VS Code "Remote Containers" functionality can be used to quickly stand up
+a configured development environment, with development-specific extensions
+automatically installed in the container.
+
+For more information abot the "Remote Containers" functionality, see
+(https://code.visualstudio.com/docs/remote/containers).
+
+### Remote Containers Setup
+
+1) Start the Drupal application using Docker Compose.
+
+2) Open VS Code.
+
+3) In the lower-left corner of the VS Code window, there is a small green
+icon "><". Left-click the icon, and select "Remote Containers: Open Folder in Container..."
+
+4) In the resulting dialog, select the directory where "drupal-common" was
+checked out to. VS Code will reset and display the files in the "drupal-common"
+directory. Container-specific extensions, such as "PHP Intellisense" and
+"phpcs" will be automatically loaded. The "Terminal" window will default to
+the "/var/www/html" in the PHP container.
+
+The "PHP CodeSniffer" linter will be automatically enabled for ".php" files
+(i.e., opening a ".php" file should automatically highlight any violations
+in the file).
+
+The "PHP CodeSniffer" can also be run from the VS Code Terminal. For example,
+to check the "web/modules/custom/" directory:
+
+            > phpcs web/modules/custom/
+            
+### Remote Containers - Enabling Debugging
+
+The "PHP Debug" extension is added to the Remote Containers configuration by
+default. However, because it seems to slow Drupal down significantly, the
+"xdebug" tool is not enabled by default.
+
+To enable the "xdebug" tools in the Docker container, do the following:
+
+1) On the host machine, stop the running Docker containers. The simplest way
+to do this is to go to the directory where "drupal-common" is checked out
+and run:
+
+            > make down
+            
+2) Prune the existing containers (this seems to be necessary, as otherwise the
+PHP container does not appear to restart properly:
+
+            > docker system prune -f
+            
+3) Edit the "docker-compose.yml" file, uncommenting the following lines:
+
+            #      PHP_XDEBUG: 1
+            #      PHP_XDEBUG_DEFAULT_ENABLE: 1
+            #      PHP_XDEBUG_REMOTE_HOST: host.docker.internal
+            #      PHP_XDEBUG_REMOTE_PORT: 9123
+            #      PHP_XDEBUG_REMOTE_CONNECT_BACK: 0
+            
+by changing them to:
+
+                   PHP_XDEBUG: 1
+                   PHP_XDEBUG_DEFAULT_ENABLE: 1
+                   PHP_XDEBUG_REMOTE_HOST: host.docker.internal
+                   PHP_XDEBUG_REMOTE_PORT: 9123
+                   PHP_XDEBUG_REMOTE_CONNECT_BACK: 0
+
+**Note:** A non-standard port of "9123" is used for "xdebug", because the
+stardard port of "9000" is exposed by the Docker container, and cannot be
+accessed via Remote Containers.
+
+4) Restart the Docker containers:
+
+            > make up
+
+Once debugging is enabled in the Docker container, the VS Code debugger can
+be used by doing the following:
+
+1) If necessary, open VS Code (or if VS Code was already running, left-click the
+"Reload Window" button). If you get a message about "Configuration files(s)
+changed", simply left-click the "Rebuild" button.
+
+2) Left-click the "Run and Debug" icon in the left-sidebar. At the top of 
+the sidebar will be a "Listen for Xdebug" dropdown, with a green "Play"
+button next to it. Left-click the green "Play" button. The status bar at the
+bottom of the VS Code will turn orange.
+
+3) Set breakpoints in the code of interest.
+
+4) In the web browser, perform whatever steps are necessary to trigger the
+code with the breakpoints. **Note:** If the breakpoint is not being triggered,
+the Drupal cache may need to be cleared.
+
+5) Once the breakpoint is hit, VS Code should display with the line containing
+the breakpoint highlighted.
+
+### Remote Containers - Disabling Debugging
+
+Since "xdebug" causes decreased performance, it can be disabled when no longer
+needed by doing the following:
+
+1) On the host machine, stop the running Docker containers. The simplest way
+to do this is to go to the directory where "drupal-common" is checked out
+and run:
+
+            > make down
+            
+2) Prune the existing containers (this seems to be necessary, as otherwise the
+PHP container does not appear to restart properly:
+
+            > docker system prune -f
+            
+3) Edit the "docker-compose.yml" file, commenting out the following lines:
+
+                   PHP_XDEBUG: 1
+                   PHP_XDEBUG_DEFAULT_ENABLE: 1
+                   PHP_XDEBUG_REMOTE_HOST: host.docker.internal
+                   PHP_XDEBUG_REMOTE_PORT: 9123
+                   PHP_XDEBUG_REMOTE_CONNECT_BACK: 0
+            
+by changing them to:
+
+            #      PHP_XDEBUG: 1
+            #      PHP_XDEBUG_DEFAULT_ENABLE: 1
+            #      PHP_XDEBUG_REMOTE_HOST: host.docker.internal
+            #      PHP_XDEBUG_REMOTE_PORT: 9123
+            #      PHP_XDEBUG_REMOTE_CONNECT_BACK: 0
+
+4) Restart the Docker containers:
+
+            > make up
+
+5) If necessary, open VS Code (or if VS Code was already running, left-click the
+"Reload Window" button). If you get a message about "Configuration files(s)
+changed", simply left-click the "Rebuild" button.

--- a/composer.json
+++ b/composer.json
@@ -117,5 +117,10 @@
                 "      composer remove drupal/core-project-message"
             ]
         }
+    },
+    "require-dev": {
+        "dealerdirect/phpcodesniffer-composer-installer": "^0.7.1",
+        "drupal/coder": "^8.3",
+        "squizlabs/php_codesniffer": "^3.6"
     }
 }

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "add6a0be2927497fd8ce2b14f24ce431",
+    "content-hash": "269ca4907ff47d5c2a7a8a486ac0afe9",
     "packages": [
         {
             "name": "asm89/stack-cors",
@@ -7652,16 +7652,16 @@
         },
         {
             "name": "squizlabs/php_codesniffer",
-            "version": "3.5.6",
+            "version": "3.6.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/squizlabs/PHP_CodeSniffer.git",
-                "reference": "e97627871a7eab2f70e59166072a6b767d5834e0"
+                "reference": "ffced0d2c8fa8e6cdc4d695a743271fab6c38625"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/squizlabs/PHP_CodeSniffer/zipball/e97627871a7eab2f70e59166072a6b767d5834e0",
-                "reference": "e97627871a7eab2f70e59166072a6b767d5834e0",
+                "url": "https://api.github.com/repos/squizlabs/PHP_CodeSniffer/zipball/ffced0d2c8fa8e6cdc4d695a743271fab6c38625",
+                "reference": "ffced0d2c8fa8e6cdc4d695a743271fab6c38625",
                 "shasum": ""
             },
             "require": {
@@ -7699,7 +7699,12 @@
                 "phpcs",
                 "standards"
             ],
-            "time": "2020-08-10T04:50:15+00:00"
+            "support": {
+                "issues": "https://github.com/squizlabs/PHP_CodeSniffer/issues",
+                "source": "https://github.com/squizlabs/PHP_CodeSniffer",
+                "wiki": "https://github.com/squizlabs/PHP_CodeSniffer/wiki"
+            },
+            "time": "2021-04-09T00:54:41+00:00"
         },
         {
             "name": "stack/builder",
@@ -9960,13 +9965,180 @@
             "time": "2015-12-17T08:42:14+00:00"
         }
     ],
-    "packages-dev": [],
+    "packages-dev": [
+        {
+            "name": "dealerdirect/phpcodesniffer-composer-installer",
+            "version": "v0.7.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/Dealerdirect/phpcodesniffer-composer-installer.git",
+                "reference": "fe390591e0241955f22eb9ba327d137e501c771c"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/Dealerdirect/phpcodesniffer-composer-installer/zipball/fe390591e0241955f22eb9ba327d137e501c771c",
+                "reference": "fe390591e0241955f22eb9ba327d137e501c771c",
+                "shasum": ""
+            },
+            "require": {
+                "composer-plugin-api": "^1.0 || ^2.0",
+                "php": ">=5.3",
+                "squizlabs/php_codesniffer": "^2.0 || ^3.0 || ^4.0"
+            },
+            "require-dev": {
+                "composer/composer": "*",
+                "phpcompatibility/php-compatibility": "^9.0",
+                "sensiolabs/security-checker": "^4.1.0"
+            },
+            "type": "composer-plugin",
+            "extra": {
+                "class": "Dealerdirect\\Composer\\Plugin\\Installers\\PHPCodeSniffer\\Plugin"
+            },
+            "autoload": {
+                "psr-4": {
+                    "Dealerdirect\\Composer\\Plugin\\Installers\\PHPCodeSniffer\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Franck Nijhof",
+                    "email": "franck.nijhof@dealerdirect.com",
+                    "homepage": "http://www.frenck.nl",
+                    "role": "Developer / IT Manager"
+                }
+            ],
+            "description": "PHP_CodeSniffer Standards Composer Installer Plugin",
+            "homepage": "http://www.dealerdirect.com",
+            "keywords": [
+                "PHPCodeSniffer",
+                "PHP_CodeSniffer",
+                "code quality",
+                "codesniffer",
+                "composer",
+                "installer",
+                "phpcs",
+                "plugin",
+                "qa",
+                "quality",
+                "standard",
+                "standards",
+                "style guide",
+                "stylecheck",
+                "tests"
+            ],
+            "support": {
+                "issues": "https://github.com/dealerdirect/phpcodesniffer-composer-installer/issues",
+                "source": "https://github.com/dealerdirect/phpcodesniffer-composer-installer"
+            },
+            "time": "2020-12-07T18:04:37+00:00"
+        },
+        {
+            "name": "drupal/coder",
+            "version": "8.3.12",
+            "source": {
+                "type": "git",
+                "url": "https://git.drupalcode.org/project/coder.git",
+                "reference": "719ddb16aec2e5da4ce274bf3bf8450caef564d4"
+            },
+            "require": {
+                "ext-mbstring": "*",
+                "php": ">=7.0.8",
+                "sirbrillig/phpcs-variable-analysis": "^2.10",
+                "squizlabs/php_codesniffer": "^3.5.6",
+                "symfony/yaml": ">=2.0.5"
+            },
+            "require-dev": {
+                "phpstan/phpstan": "^0.12.51",
+                "phpunit/phpunit": "^6.0 || ^7.0"
+            },
+            "type": "phpcodesniffer-standard",
+            "autoload": {
+                "psr-4": {
+                    "Drupal\\": "coder_sniffer/Drupal/",
+                    "DrupalPractice\\": "coder_sniffer/DrupalPractice/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "GPL-2.0-or-later"
+            ],
+            "description": "Coder is a library to review Drupal code.",
+            "homepage": "https://www.drupal.org/project/coder",
+            "keywords": [
+                "code review",
+                "phpcs",
+                "standards"
+            ],
+            "support": {
+                "issues": "https://www.drupal.org/project/issues/coder",
+                "source": "https://www.drupal.org/project/coder"
+            },
+            "time": "2020-12-06T09:34:55+00:00"
+        },
+        {
+            "name": "sirbrillig/phpcs-variable-analysis",
+            "version": "v2.11.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sirbrillig/phpcs-variable-analysis.git",
+                "reference": "e76e816236f401458dd8e16beecab905861b5867"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sirbrillig/phpcs-variable-analysis/zipball/e76e816236f401458dd8e16beecab905861b5867",
+                "reference": "e76e816236f401458dd8e16beecab905861b5867",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.4.0",
+                "squizlabs/php_codesniffer": "^3.5"
+            },
+            "require-dev": {
+                "dealerdirect/phpcodesniffer-composer-installer": "^0.7.0",
+                "limedeck/phpunit-detailed-printer": "^3.1 || ^4.0 || ^5.0",
+                "phpstan/phpstan": "^0.11.8",
+                "phpunit/phpunit": "^5.0 || ^6.5 || ^7.0 || ^8.0",
+                "sirbrillig/phpcs-import-detection": "^1.1"
+            },
+            "type": "phpcodesniffer-standard",
+            "autoload": {
+                "psr-4": {
+                    "VariableAnalysis\\": "VariableAnalysis/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-2-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sam Graham",
+                    "email": "php-codesniffer-variableanalysis@illusori.co.uk"
+                },
+                {
+                    "name": "Payton Swick",
+                    "email": "payton@foolord.com"
+                }
+            ],
+            "description": "A PHPCS sniff to detect problems with variables.",
+            "support": {
+                "issues": "https://github.com/sirbrillig/phpcs-variable-analysis/issues",
+                "source": "https://github.com/sirbrillig/phpcs-variable-analysis",
+                "wiki": "https://github.com/sirbrillig/phpcs-variable-analysis/wiki"
+            },
+            "time": "2021-03-09T22:32:14+00:00"
+        }
+    ],
     "aliases": [
         {
-            "alias": "3.4.41",
-            "alias_normalized": "3.4.41.0",
+            "package": "symfony/event-dispatcher",
             "version": "4.3.11.0",
-            "package": "symfony/event-dispatcher"
+            "alias": "3.4.41",
+            "alias_normalized": "3.4.41.0"
         }
     ],
     "minimum-stability": "dev",
@@ -9982,5 +10154,6 @@
     "prefer-stable": true,
     "prefer-lowest": false,
     "platform": [],
-    "platform-dev": []
+    "platform-dev": [],
+    "plugin-api-version": "2.0.0"
 }

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -16,6 +16,11 @@ services:
       PHP_FPM_USER: wodby
       PHP_FPM_GROUP: wodby
       COLUMNS: 80 # Set 80 columns for docker exec -it.
+#      PHP_XDEBUG: 1
+#      PHP_XDEBUG_DEFAULT_ENABLE: 1
+#      PHP_XDEBUG_REMOTE_HOST: host.docker.internal
+#      PHP_XDEBUG_REMOTE_PORT: 9123
+#      PHP_XDEBUG_REMOTE_CONNECT_BACK: 0
 
     volumes:
       - ./:/var/www/html:cached
@@ -101,10 +106,6 @@ services:
 #      - docker-sync:/var/www/html
 #    labels:
 #      - "traefik.http.routers.${PROJECT_NAME}_apache.rule=Host(`${PROJECT_BASE_URL}`)"
-
-  redis:
-    container_name: "${PROJECT_NAME}_redis"
-    image: wodby/redis:$REDIS_TAG
 
 #  adminer:
 #    container_name: "${PROJECT_NAME}_adminer"

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ruleset name="myproject">
+  <description>PHP CodeSniffer configuration for myproject development.</description>
+  <!-- Check all files in the current directory and below. -->
+  <file>.</file>
+  <arg name="extensions" value="php,module,inc,install,test,profile,theme,css,info,txt,md,yml"/>
+  <!-- Change this value to 7 if you want to check Drupal 7 code. -->
+  <config name="drupal_core_version" value="8"/>
+
+  <!-- If you have Coder installed locally then you can reference the Drupal
+  standards with relative paths. Otherwise simply use "Drupal" and
+  "DrupalPractice. -->
+  <rule ref="vendor/drupal/coder/coder_sniffer/Drupal">
+    <!-- Example how you would disable a rule you are not compliant with yet:
+    <exclude name="Drupal.Commenting.Deprecated"/>
+    -->
+  </rule>
+  <rule ref="vendor/drupal/coder/coder_sniffer/DrupalPractice"/>
+
+  <!-- Example how you would disable an external rule you do not like:
+  <rule ref="PEAR.Functions.ValidDefaultValue.NotAtEnd">
+    <severity>0</severity>
+  </rule>
+  -->
+</ruleset>


### PR DESCRIPTION
Configuration files for enabling VS Code "Remote Containers" to set up
a usable Drupal development environment.

In "docker-compose.yml", a duplicate "redis" definition was removed and
commented-out "PHP_XDEBUG" configuration parameters were added. The
"PHP_XDEBUG" configuration is commented out because it can significantly
degrade performance.

Added ".devcontainer/devcontainer.json" to configure the VS Code
extensions to automatically install into the container, and
".vscode/launch.json" to configure a debug launcher.

Updated the README.md.

https://issues.umd.edu/browse/LIBITD-1894