### PR TITLE
LIBWEB-5395. Updated local deployment steps in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,13 +7,17 @@ installed.
 
 (Recommended) Add the following to your **~/.profile**:
 
-            alias composer="composer.phar"
+```
+alias composer="composer.phar"
+```
 
 Add the following to your /etc/hosts (customized if you wish):
 
-            127.0.0.1		www.docker.localhost
-            127.0.0.1		portainer.drupal.docker.localhost
-            127.0.0.1		solr.drupal.docker.localhost
+```
+127.0.0.1		www.docker.localhost
+127.0.0.1		portainer.drupal.docker.localhost
+127.0.0.1		solr.drupal.docker.localhost
+```
 
 ## Local Deploy
 
@@ -22,34 +26,44 @@ Add the following to your /etc/hosts (customized if you wish):
 Create a base directory to hold each of the directories for the project. This
 example will use "drupal", but that is arbitrary:
 
-            > mkdir drupal
-            > cd drupal
+```
+> mkdir drupal
+> cd drupal
+```
 
 To deploy locally, clone the main branch:
 
-            > git clone https://github.com/umd-lib/drupal-common.git common-www
-            > cd common-www
-            > git checkout feature/LIBWEB-5305 (temporary development branch)
+```
+> git clone https://github.com/umd-lib/drupal-common.git common-www
+> cd common-www
+> git checkout feature/LIBWEB-5305 (temporary development branch)
+```
 
 Install the site using Composer. This will download all dependencies and prep
 for local deployment.
 
-            # in common-www/
-            > composer install
+```
+# in common-www/
+> composer install
+```
 
 Switch back to the base ("drupal") directory, and create empty directories for the
 Postgres and Solr data (used in the next steps):
 
-            > cd ..  # back to "drupal"
-            > mkdir postgres_data
-            > mkdir solr_data
+```
+> cd ..  # back to "drupal"
+> mkdir postgres_data
+> mkdir solr_data
+```
 
 Clone the drupal-projects-env repository locally and copy the demo/env file
 into your web root (i.e., common-demo) as .env:
 
-            > git clone git@github.com:umd-lib/drupal-projects-env.git
-            > cp drupal-projects-env/www/env common-www/.env
-            > cp drupal-projects-env/www/settings.php common-www/web/sites/default/settings.php
+```
+> git clone git@github.com:umd-lib/drupal-projects-env.git
+> cp drupal-projects-env/www/env common-www/.env
+> cp drupal-projects-env/www/settings.php common-www/web/sites/default/settings.php
+```
 
 Customize the common-www/.env file for your environment. Specifically, look at
 the values for:
@@ -59,7 +73,9 @@ the values for:
 
 Get a recent database dump from production, and copy to postgres-init:
 
-            > cp wwwnew.sql common-www/postgres-init/
+```
+> cp wwwnew.sql common-www/postgres-init/
+```
 
 (See below for instructions for generating the sql dump).
 
@@ -67,14 +83,18 @@ All other values can stay the same.
 
 To bring up the site, use docker-compose:
 
-            > cd common-www
-            > docker-compose up -d
+```
+> cd common-www
+> docker-compose up -d
+```
 
 Note that it is very likely you will need to flush cache before the site will
 properly appear. Wait a minute before performing this to ensure the stack is
 fully started.
 
-            > make drush cr
+```
+> make drush cr
+```
 
 Unless clearing cache produces errors, the site should be available at:
 
@@ -82,11 +102,15 @@ Unless clearing cache produces errors, the site should be available at:
 
 If the site fails to come up, kill the stack with:
 
-            > docker-compose down
+```
+> docker-compose down
+```
 
 And restart without the -d in order to pump logging to standard out.
 
-            > docker-compose up
+```
+> docker-compose up
+```
 
 If your work depends on having all images in place, you will want to generate a dump
 from production. These can be copied to common-www/web/sites/default/files/
@@ -115,21 +139,27 @@ using *Clear Cache* with some frequency.
 
 To dump SQL data from the Kubernetes cluster:
 
-            > cd common-www/
-            > kubectl exec drupal-www-db-0 -- pg_dump -c -O -U drupaldb -d drupaldb > postgres-init/wwwnew.sql
+```
+> cd common-www/
+> kubectl exec drupal-www-db-0 -- pg_dump -c -O -U drupaldb -d drupaldb > postgres-init/wwwnew.sql
+```
 
 Dumping Local Database (generally not needed)
 
-           > docker exec wwwnew_postgres pg_dump -U drupaluser -O drupaldb > /tmp/dump.sql
+```
+> docker exec wwwnew_postgres pg_dump -U drupaluser -O drupaldb > /tmp/dump.sql
+```
 
 ### Files Copy
 
 To copy files you might need from the server into your local:
 
-            > kubectl exec --stdin --tty drupal-wwwnew-0 -- /bin/bash
-            > tar -czvf files.tgz web/sites/default/files/
-            > exit
-            > kubectl cp drupal-www-0:files.tgz common-www/
+```
+> kubectl exec --stdin --tty drupal-wwwnew-0 -- /bin/bash
+> tar -czvf files.tgz web/sites/default/files/
+> exit
+> kubectl cp drupal-www-0:files.tgz common-www/
+```
 
 And then extract the archive into your local's web/sites/default/files/.
 
@@ -142,8 +172,10 @@ and may need to have CSS/JS aggregation turned off and modules such as devel ena
 
 To create a local Solr core with through docker-compose, do the following:
 
-            > docker exec -ti wwwnew_solr sh
-            > /opt/solr/bin/solr create_core -c drupal -d /opt/solr/server/solr/configsets/search_api_solr_8.x-3.9/conf/
+```
+> docker exec -ti wwwnew_solr sh
+> /opt/solr/bin/solr create_core -c drupal -d /opt/solr/server/solr/configsets/search_api_solr_8.x-3.9/conf/
+```
 
 ### SAML Integration
 
@@ -177,12 +209,16 @@ The current configuration is defined in the "phpcs.xml.dist" file.
 
 To check a particular directory or file, run the following commands:
 
-            > vendor/bin/phpcs <DIRECTORY_OR_FILE>
+```
+> vendor/bin/phpcs <DIRECTORY_OR_FILE>
+```
 
 where <DIRECTORY_OR_FILE> is the name of the directory or file. For example,
 to check the code in the "web/modules/custom/" directory, run:
 
-            > vendor/bin/phpcs web/modules/custom/
+```
+> vendor/bin/phpcs web/modules/custom/
+```
 
 ## VS Code Remote Containers
 
@@ -215,7 +251,9 @@ in the file).
 The "PHP CodeSniffer" can also be run from the VS Code Terminal. For example,
 to check the "web/modules/custom/" directory:
 
-            > phpcs web/modules/custom/
+```
+> phpcs web/modules/custom/
+```
 
 ### Remote Containers - Enabling Debugging
 
@@ -229,28 +267,36 @@ To enable the "xdebug" tools in the Docker container, do the following:
 to do this is to go to the directory where "drupal-common" is checked out
 and run:
 
-            > make down
+```
+> make down
+```
 
 2) Prune the existing containers (this seems to be necessary, as otherwise the
 PHP container does not appear to restart properly:
 
-            > docker system prune -f
+```
+> docker system prune -f
+```
 
 3) Edit the "docker-compose.yml" file, uncommenting the following lines:
 
-            #      PHP_XDEBUG: 1
-            #      PHP_XDEBUG_DEFAULT_ENABLE: 1
-            #      PHP_XDEBUG_REMOTE_HOST: host.docker.internal
-            #      PHP_XDEBUG_REMOTE_PORT: 9123
-            #      PHP_XDEBUG_REMOTE_CONNECT_BACK: 0
+```
+#      PHP_XDEBUG: 1
+#      PHP_XDEBUG_DEFAULT_ENABLE: 1
+#      PHP_XDEBUG_REMOTE_HOST: host.docker.internal
+#      PHP_XDEBUG_REMOTE_PORT: 9123
+#      PHP_XDEBUG_REMOTE_CONNECT_BACK: 0
+```
 
 by changing them to:
 
-                   PHP_XDEBUG: 1
-                   PHP_XDEBUG_DEFAULT_ENABLE: 1
-                   PHP_XDEBUG_REMOTE_HOST: host.docker.internal
-                   PHP_XDEBUG_REMOTE_PORT: 9123
-                   PHP_XDEBUG_REMOTE_CONNECT_BACK: 0
+```
+PHP_XDEBUG: 1
+PHP_XDEBUG_DEFAULT_ENABLE: 1
+PHP_XDEBUG_REMOTE_HOST: host.docker.internal
+PHP_XDEBUG_REMOTE_PORT: 9123
+PHP_XDEBUG_REMOTE_CONNECT_BACK: 0
+```
 
 **Note:** A non-standard port of "9123" is used for "xdebug", because the
 stardard port of "9000" is exposed by the Docker container, and cannot be
@@ -258,7 +304,9 @@ accessed via Remote Containers.
 
 4) Restart the Docker containers:
 
-            > make up
+```
+> make up
+```
 
 Once debugging is enabled in the Docker container, the VS Code debugger can
 be used by doing the following:
@@ -290,32 +338,42 @@ needed by doing the following:
 to do this is to go to the directory where "drupal-common" is checked out
 and run:
 
-            > make down
+```
+> make down
+```
 
 2) Prune the existing containers (this seems to be necessary, as otherwise the
 PHP container does not appear to restart properly:
 
-            > docker system prune -f
+```
+> docker system prune -f
+```
 
 3) Edit the "docker-compose.yml" file, commenting out the following lines:
 
-                   PHP_XDEBUG: 1
-                   PHP_XDEBUG_DEFAULT_ENABLE: 1
-                   PHP_XDEBUG_REMOTE_HOST: host.docker.internal
-                   PHP_XDEBUG_REMOTE_PORT: 9123
-                   PHP_XDEBUG_REMOTE_CONNECT_BACK: 0
+```
+PHP_XDEBUG: 1
+PHP_XDEBUG_DEFAULT_ENABLE: 1
+PHP_XDEBUG_REMOTE_HOST: host.docker.internal
+PHP_XDEBUG_REMOTE_PORT: 9123
+PHP_XDEBUG_REMOTE_CONNECT_BACK: 0
+```
 
 by changing them to:
 
-            #      PHP_XDEBUG: 1
-            #      PHP_XDEBUG_DEFAULT_ENABLE: 1
-            #      PHP_XDEBUG_REMOTE_HOST: host.docker.internal
-            #      PHP_XDEBUG_REMOTE_PORT: 9123
-            #      PHP_XDEBUG_REMOTE_CONNECT_BACK: 0
+```
+#      PHP_XDEBUG: 1
+#      PHP_XDEBUG_DEFAULT_ENABLE: 1
+#      PHP_XDEBUG_REMOTE_HOST: host.docker.internal
+#      PHP_XDEBUG_REMOTE_PORT: 9123
+#      PHP_XDEBUG_REMOTE_CONNECT_BACK: 0
+```
 
 4) Restart the Docker containers:
 
-            > make up
+```
+> make up
+```
 
 5) If necessary, open VS Code (or if VS Code was already running, left-click the
 "Reload Window" button). If you get a message about "Configuration files(s)

--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ All other values can stay the same.
 and copy to postgres-init:
 
 ```
-> kubectl config get-contexts prod
+> kubectl config use-context prod
 > kubectl exec drupal-www-db-0 -- pg_dump -c --if-exists -O -U drupaldb -d drupaldb > common-www/postgres-init/wwwnew.sql
 ```
 
@@ -130,10 +130,9 @@ And restart without the -d in order to pump logging to standard out.
 
 10) If your work depends on having all images in place, you will want to
 generate a dump from production. These can be copied to
+`common-www/web/sites/default/files/`.
 
-common-www/web/sites/default/files/
-
-See instructions below.
+See the "Files Copy" section below.
 
 Be sure to flush cache after the file copy is complete.
 
@@ -175,7 +174,7 @@ Dumping Local Database (generally not needed)
 To copy files you might need from the server into your local:
 
 ```
-# In "drupal"
+# In "drupal" (and with Kubernetes set to the appropriate namespace)
 > kubectl exec --stdin --tty drupal-www-0 -- /bin/bash
 drupal-www-0> tar -czvf files.tgz web/sites/default/files/
 drupal-www-0> exit

--- a/README.md
+++ b/README.md
@@ -109,7 +109,7 @@ Under *Extend*, you can enable the *Devel* module, which, among other features,
 provides a *Clear Cache* link on the toolbar.  You're in Drupal now and will be
 using *Clear Cache* with some frequency.
 
-## Additional Help 
+## Additional Help
 
 ### Database Dump
 
@@ -148,7 +148,7 @@ To create a local Solr core with through docker-compose, do the following:
 ### SAML Integration
 
 SAML is available for local development but not immediately available if working
-with a k8s server database dump. 
+with a k8s server database dump.
 
 Place the key and cert in the drupal-common root under certs/. So for example:
 
@@ -178,7 +178,7 @@ The current configuration is defined in the "phpcs.xml.dist" file.
 To check a particular directory or file, run the following commands:
 
             > vendor/bin/phpcs <DIRECTORY_OR_FILE>
-            
+
 where <DIRECTORY_OR_FILE> is the name of the directory or file. For example,
 to check the code in the "web/modules/custom/" directory, run:
 
@@ -216,7 +216,7 @@ The "PHP CodeSniffer" can also be run from the VS Code Terminal. For example,
 to check the "web/modules/custom/" directory:
 
             > phpcs web/modules/custom/
-            
+
 ### Remote Containers - Enabling Debugging
 
 The "PHP Debug" extension is added to the Remote Containers configuration by
@@ -230,12 +230,12 @@ to do this is to go to the directory where "drupal-common" is checked out
 and run:
 
             > make down
-            
+
 2) Prune the existing containers (this seems to be necessary, as otherwise the
 PHP container does not appear to restart properly:
 
             > docker system prune -f
-            
+
 3) Edit the "docker-compose.yml" file, uncommenting the following lines:
 
             #      PHP_XDEBUG: 1
@@ -243,7 +243,7 @@ PHP container does not appear to restart properly:
             #      PHP_XDEBUG_REMOTE_HOST: host.docker.internal
             #      PHP_XDEBUG_REMOTE_PORT: 9123
             #      PHP_XDEBUG_REMOTE_CONNECT_BACK: 0
-            
+
 by changing them to:
 
                    PHP_XDEBUG: 1
@@ -267,7 +267,7 @@ be used by doing the following:
 "Reload Window" button). If you get a message about "Configuration files(s)
 changed", simply left-click the "Rebuild" button.
 
-2) Left-click the "Run and Debug" icon in the left-sidebar. At the top of 
+2) Left-click the "Run and Debug" icon in the left-sidebar. At the top of
 the sidebar will be a "Listen for Xdebug" dropdown, with a green "Play"
 button next to it. Left-click the green "Play" button. The status bar at the
 bottom of the VS Code will turn orange.
@@ -291,12 +291,12 @@ to do this is to go to the directory where "drupal-common" is checked out
 and run:
 
             > make down
-            
+
 2) Prune the existing containers (this seems to be necessary, as otherwise the
 PHP container does not appear to restart properly:
 
             > docker system prune -f
-            
+
 3) Edit the "docker-compose.yml" file, commenting out the following lines:
 
                    PHP_XDEBUG: 1
@@ -304,7 +304,7 @@ PHP container does not appear to restart properly:
                    PHP_XDEBUG_REMOTE_HOST: host.docker.internal
                    PHP_XDEBUG_REMOTE_PORT: 9123
                    PHP_XDEBUG_REMOTE_CONNECT_BACK: 0
-            
+
 by changing them to:
 
             #      PHP_XDEBUG: 1

--- a/README.md
+++ b/README.md
@@ -79,13 +79,13 @@ modify the values for:
 
 All other values can stay the same.
 
-7) Get a recent database dump from production, and copy to postgres-init:
+7) Get a recent database dump from production (or qa/test, as desired),
+and copy to postgres-init:
 
 ```
-> cp wwwnew.sql common-www/postgres-init/
+> kubectl config get-contexts prod
+> kubectl exec drupal-www-db-0 -- pg_dump -c --if-exists -O -U drupaldb -d drupaldb > common-www/postgres-init/wwwnew.sql
 ```
-
-(See below for instructions for generating the sql dump).
 
 8) (Optional - Local development only) Copy drupal-projects-env/services.yml
 to common-demo/web/sites/default/:
@@ -160,9 +160,8 @@ using *Clear Cache* with some frequency.
 To dump SQL data from the Kubernetes cluster:
 
 ```
-> cd common-www/
-> kubectl exec drupal-www-db-0 -- pg_dump -c --if-exists -O -U drupaldb -d drupaldb > postgres-init/wwwnew.sql
-> cd ..
+# In "drupal"
+> kubectl exec drupal-www-db-0 -- pg_dump -c --if-exists -O -U drupaldb -d drupaldb > common-www/postgres-init/wwwnew.sql
 ```
 
 Dumping Local Database (generally not needed)
@@ -176,9 +175,10 @@ Dumping Local Database (generally not needed)
 To copy files you might need from the server into your local:
 
 ```
+# In "drupal"
 > kubectl exec --stdin --tty drupal-www-0 -- /bin/bash
-> tar -czvf files.tgz web/sites/default/files/
-> exit
+drupal-www-0> tar -czvf files.tgz web/sites/default/files/
+drupal-www-0> exit
 > kubectl cp drupal-www-0:files.tgz common-www/files.tgz
 ```
 
@@ -187,13 +187,11 @@ And then extract the archive into your local's web/sites/default/files/:
 ```
 > cd common-www
 > tar -xvzf files.tgz
-> cd ..
 ```
 
 Flush cache after this so that Drupal can regenerate any thumbnails, etc:
 
 ```
-> cd common-www
 > make drush cr
 > cd ..
 ```

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 ## Prerequisites
 
-Install the latest **Composer** (https://getcomposer.org/download/) if not already
+Install the latest **Composer** <https://getcomposer.org/download/> if not already
 installed.
 
 (Recommended) Add the following to your **~/.profile**:
@@ -98,7 +98,7 @@ fully started.
 
 Unless clearing cache produces errors, the site should be available at:
 
-* http://www.docker.localhost:18080
+* <http://www.docker.localhost:18080>
 
 If the site fails to come up, kill the stack with:
 
@@ -202,7 +202,7 @@ Save and test logging in at /user.
 
 ### PHP CodeSniffer
 
-PHP CodeSniffer (https://github.com/squizlabs/PHP_CodeSniffer) is a linter for
+PHP CodeSniffer <https://github.com/squizlabs/PHP_CodeSniffer> is a linter for
 identifying coding standard violations.
 
 The current configuration is defined in the "phpcs.xml.dist" file.
@@ -227,7 +227,7 @@ a configured development environment, with development-specific extensions
 automatically installed in the container.
 
 For more information abot the "Remote Containers" functionality, see
-(https://code.visualstudio.com/docs/remote/containers).
+<https://code.visualstudio.com/docs/remote/containers>.
 
 ### Remote Containers Setup
 

--- a/README.md
+++ b/README.md
@@ -210,24 +210,8 @@ To create a local Solr core with through docker-compose, do the following:
 
 ### SAML Integration
 
-SAML is available for local development but not immediately available if working
-with a k8s server database dump.
-
-Place the key and cert in the drupal-common root under certs/. So for example:
-
-* common-www/certs/sp.key
-* common-www/certs/sp.crt
-
-Log into Drupal using the legacy login and access /admin/config/people/saml
-
-Under *Service Provider*, set the following values:
-
-* Entity ID: wwwnew-test.lib.umd.edu
-* Certificate folder: /var/www/html
-
-All other values can stay the same.
-
-Save and test logging in at /user.
+For UMD users, see the "drupal-common SAML Setup" page in Confluence
+(<https://confluence.umd.edu/display/ULDW/drupal-common+SAML+Setup>).
 
 ## Tools
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -40,7 +40,7 @@ services:
       NGINX_BACKEND_HOST: php
       NGINX_SERVER_ROOT: /var/www/html/web
       NGINX_VHOST_PRESET: $NGINX_VHOST_PRESET
-      NGINX_DRUPAL_FILE_PROXY_URL: http://example.com
+      # NGINX_DRUPAL_FILE_PROXY_URL: http://example.com
     volumes:
       - ./:/var/www/html:cached
 ## Alternative for macOS users: docker-sync https://wodby.com/docs/stacks/drupal/local#docker-for-mac


### PR DESCRIPTION
1) Modified the README.md file to be closer to SSDR guidance for formatting Markdown documents (https://confluence.umd.edu/display/LIB/Markdown+Style+Guide):
* Removed trailing whitespace from all lines
* Changed indented code blocks to "fenced" code blocks
* Fixed "bare URLs"

2) Added step numbering and updated steps to match changes in the branch.

3) Added a database dump instructions step "in-line", instead of referencing
a different section of the document.

4) Made updates to the "Files Copy" instructions.

5) Replaced "SAML Integration" section with link to a Confluence page (https://confluence.umd.edu/display/ULDW/drupal-common+SAML+Setup) in the DST Private Workspace

6) In "docker-compose.yml", commented out the "NGINX_DRUPAL_FILE_PROXY_URL" setting, as it was interfering with the display of images of websites running locally.

https://issues.umd.edu/browse/LIBWEB-5395