### PR TITLE
LIBWEB-5389. Implementation of Utility Nav with System Status retrieval

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -40,6 +40,7 @@
         "drupal/extlink": "^1.3",
         "drupal/fakeobjects": "^1.0",
         "drupal/field_group": "^3.1",
+        "drupal/fixed_block_content": "^1.1",
         "drupal/fontawesome": "^2.16",
         "drupal/google_tag": "^1.4",
         "drupal/honeypot": "^1.30",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "76048d342e76849a3e13228097f550e0",
+    "content-hash": "7354716f8d197f26531a00d20c5ceb0c",
     "packages": [
         {
             "name": "asm89/stack-cors",
@@ -3493,6 +3493,55 @@
             }
         },
         {
+            "name": "drupal/fixed_block_content",
+            "version": "1.1.0",
+            "source": {
+                "type": "git",
+                "url": "https://git.drupalcode.org/project/fixed_block_content.git",
+                "reference": "8.x-1.1"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://ftp.drupal.org/files/projects/fixed_block_content-8.x-1.1.zip",
+                "reference": "8.x-1.1",
+                "shasum": "567351ee7a1f40b43ff81ede9afc085f78752d20"
+            },
+            "require": {
+                "drupal/core": "~8.7 || ^9"
+            },
+            "type": "drupal-module",
+            "extra": {
+                "drupal": {
+                    "version": "8.x-1.1",
+                    "datestamp": "1585994766",
+                    "security-coverage": {
+                        "status": "covered",
+                        "message": "Covered by Drupal's security advisory policy"
+                    }
+                }
+            },
+            "notification-url": "https://packages.drupal.org/8/downloads",
+            "license": [
+                "GPL-2.0-or-later"
+            ],
+            "authors": [
+                {
+                    "name": "Manuel Adan",
+                    "homepage": "https://www.drupal.org/user/516420",
+                    "role": "Maintainer"
+                }
+            ],
+            "description": "Provides fixed placements for custom blocks.",
+            "homepage": "http://drupal.org/project/fixed_block_content",
+            "keywords": [
+                "Drupal"
+            ],
+            "support": {
+                "source": "https://cgit.drupalcode.org/fixed_block_content",
+                "issues": "https://drupal.org/project/issues/fixed_block_content"
+            }
+        },
+        {
             "name": "drupal/fontawesome",
             "version": "2.18.0",
             "source": {
@@ -6851,7 +6900,8 @@
             "support": {
                 "source": "https://git.drupalcode.org/project/typed_data",
                 "issues": "https://www.drupal.org/project/issues/typed_data"
-            }
+            },
+            "time": "2021-06-14T20:31:09+00:00"
         },
         {
             "name": "drupal/upgrade_status",
@@ -12751,10 +12801,10 @@
     ],
     "aliases": [
         {
-            "package": "symfony/event-dispatcher",
-            "version": "4.3.11.0",
             "alias": "3.4.41",
-            "alias_normalized": "3.4.41.0"
+            "alias_normalized": "3.4.41.0",
+            "version": "4.3.11.0",
+            "package": "symfony/event-dispatcher"
         }
     ],
     "minimum-stability": "dev",
@@ -12776,5 +12826,5 @@
     "prefer-lowest": false,
     "platform": [],
     "platform-dev": [],
-    "plugin-api-version": "2.0.0"
+    "plugin-api-version": "1.1.0"
 }

--- a/web/modules/custom/system_status/README.md
+++ b/web/modules/custom/system_status/README.md
@@ -1,6 +1,7 @@
 # System Status module
 
-This module provides a cached system status json endpoint that pulls data from external system status json service.
+This module provides a cached system status json endpoint that pulls data from
+external system status json service.
 
 ## Setup
 
@@ -8,4 +9,29 @@ Enable the "System Status" module in "Manage | Extend"
 
 ## Config
 
-The configuration for the upstream System Status JSON API url will be available in the "Drupal Configuration" page > "SYSTEM" section > "System Status" (/admin/config/system/system_status).
+The configuration for the upstream System Status JSON API url will be available
+in the "Drupal Configuration" page > "SYSTEM" section > "System Status"
+(/admin/config/system/system_status), or by running the following "drush"
+command:
+
+```
+> drush config:set --yes system_status.settings service_url '<URL>'
+```
+
+where \<URL> is the URL of the API endpoint. For example, if the URL is
+"http://docker.for.mac.localhost:4567/status", the command would be:
+
+```
+> drush config:set --yes system_status.settings service_url 'http://docker.for.mac.localhost:4567/status'
+```
+
+## JavaScript
+
+This module includes JavaScript for updating the "Systems Status" menu item in
+the "utility navigation" menu provided by the "utility_nav" module.
+
+## Testing
+
+The system status endpoint can be tested in the local development environment
+using the "system-status" Docker image
+(see <https://github.com/umd-lib/system-status/>).

--- a/web/modules/custom/system_status/config/install/system_status.settings.yml
+++ b/web/modules/custom/system_status/config/install/system_status.settings.yml
@@ -1,0 +1,1 @@
+service_url: ''

--- a/web/modules/custom/system_status/js/system_status.js
+++ b/web/modules/custom/system_status/js/system_status.js
@@ -1,0 +1,45 @@
+(function ($, Drupal, drupalSettings) {
+  'use strict';
+
+  Drupal.behaviors.systemStatusBehavior = {
+    attach: function (context, settings) {
+      function retrieveStatus(systemStatusUrl) {
+        if (systemStatusUrl === undefined) {
+          return;
+        }
+        $.getJSON( systemStatusUrl, function( data ) {
+          if (data === undefined) {
+            return;
+          }
+
+          var nonNormalCount = data['non_normal']
+          if (nonNormalCount === undefined) {
+            return;
+          }
+
+          if (nonNormalCount == 0) {
+            // No further action if all systems are operational
+            return;
+          }
+
+          var utilityNavItem = $(context).find('.umd-utility-nav-status');
+          if (utilityNavItem === undefined) {
+            return;
+          }
+
+
+          var currentCaption = utilityNavItem[0].textContent
+          var nonNormalCaption = '<span class="badge">'+nonNormalCount+'</span>';
+          utilityNavItem.html(currentCaption + " " + nonNormalCaption);
+        });
+      }
+
+      $('html').once('systemStatusBehavior').each(function () {
+        var systemStatusUrl = drupalSettings.system_status.system_status_url;
+        retrieveStatus(systemStatusUrl);
+      });
+    }
+  };
+})(jQuery, Drupal, drupalSettings);
+
+

--- a/web/modules/custom/system_status/js/system_status.js
+++ b/web/modules/custom/system_status/js/system_status.js
@@ -3,10 +3,18 @@
 
   Drupal.behaviors.systemStatusBehavior = {
     attach: function (context, settings) {
+      /**
+       * Retrieves the systems status from the given endpoint, and updates
+       * the "Systems Status" entry in the utility navigation menu
+       */
       function retrieveStatus(systemStatusUrl) {
-        if (systemStatusUrl === undefined) {
+        var utilityNavItem = $(context).find('.umd-utility-nav-status');
+
+        if (utilityNavItem === undefined || utilityNavItem[0] === undefined) {
+          // Status menu item not on page
           return;
         }
+
         $.getJSON( systemStatusUrl, function( data ) {
           if (data === undefined) {
             return;
@@ -21,12 +29,6 @@
             // No further action if all systems are operational
             return;
           }
-
-          var utilityNavItem = $(context).find('.umd-utility-nav-status');
-          if (utilityNavItem === undefined) {
-            return;
-          }
-
 
           var currentCaption = utilityNavItem[0].textContent
           var nonNormalCaption = '<span class="badge">'+nonNormalCount+'</span>';

--- a/web/modules/custom/system_status/js/system_status.js
+++ b/web/modules/custom/system_status/js/system_status.js
@@ -8,7 +8,7 @@
        * the "Systems Status" entry in the utility navigation menu
        */
       function retrieveStatus(systemStatusUrl) {
-        var utilityNavItem = $(context).find('.umd-utility-nav-status');
+        var utilityNavItem = $(context).find('.utility-nav-systems-status');
 
         if (utilityNavItem === undefined || utilityNavItem[0] === undefined) {
           // Status menu item not on page

--- a/web/modules/custom/system_status/system_status.info.yml
+++ b/web/modules/custom/system_status/system_status.info.yml
@@ -7,5 +7,6 @@ type: module
 dependencies:
   - easy_install
   - libraries_configuration
+  - utility_nav
 
 core_version_requirement: ^8.9 || ^9

--- a/web/modules/custom/system_status/system_status.libraries.yml
+++ b/web/modules/custom/system_status/system_status.libraries.yml
@@ -1,0 +1,8 @@
+system_status-global:
+  version: 1.0.0
+  js:
+    js/system_status.js: {}
+  dependencies:
+    - core/jquery
+    - core/drupal
+    - core/jquery.once

--- a/web/modules/custom/system_status/system_status.module
+++ b/web/modules/custom/system_status/system_status.module
@@ -3,3 +3,15 @@
  * @file
  * Module file for the system_status module
  */
+
+/**
+ * @param $variables
+ */
+function system_status_preprocess_page(&$variables)
+{
+  $system_status_url = Drupal\Core\Url::fromRoute('system_status.status_json')->toString();
+  //Add a JS library
+  $variables['#attached']['library'][] = 'system_status/system_status-global';
+  // pass variable to Drupal.Settings
+  $variables['#attached']['drupalSettings']['system_status']['system_status_url'] = $system_status_url;
+}

--- a/web/modules/custom/utility_nav/README.md
+++ b/web/modules/custom/utility_nav/README.md
@@ -1,0 +1,30 @@
+# Utility Navigation module
+
+This module provides a utility navigation menu as a static HTML block.
+
+A static HTML block was used, instead of core Drupal menu functionality, as
+the desired appearance of the menu required greater HTML flexibility than seemed
+available with menus.
+
+This module uses the "fixed_block_content" module
+(<https://www.drupal.org/project/fixed_block_content>) to provide a default
+implementation of the menu in the YAML configuration.
+
+## Setup
+
+Enable the "Utility Nav" module in "Manage | Extend", or run the following
+"drush" command:
+
+```
+> drush --yes pm:enable utility_nav
+```
+
+## Configuration
+
+A default implementation of the utility navigation menu is provided via YAML
+configuration.
+
+The utility navigation menu can be modified by changing the editing the
+"Utility Navigation Fixed Block" block on the
+"Manage | Structure | Block Layout | Custom block library" page
+(/admin/structure/block/block-content).

--- a/web/modules/custom/utility_nav/config/install/block.block.utilitynavigationfixedblock.yml
+++ b/web/modules/custom/utility_nav/config/install/block.block.utilitynavigationfixedblock.yml
@@ -1,0 +1,22 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - fixed_block_content.fixed_block_content.utility_navigation_fixed_block
+  module:
+    - fixed_block_content
+  theme:
+    - umd_terp
+id: utilitynavigationfixedblock
+theme: umd_terp
+region: main_menu
+weight: 0
+provider: null
+plugin: 'fixed_block_content:utility_navigation_fixed_block'
+settings:
+  id: 'fixed_block_content:utility_navigation_fixed_block'
+  label: 'Utility Navigation Fixed Block'
+  provider: fixed_block_content
+  label_display: visible
+  view_mode: ''
+visibility: {  }

--- a/web/modules/custom/utility_nav/config/install/block_content.type.utility_navigation_block.yml
+++ b/web/modules/custom/utility_nav/config/install/block_content.type.utility_navigation_block.yml
@@ -1,0 +1,7 @@
+langcode: en
+status: true
+dependencies: {  }
+id: utility_navigation_block
+label: 'Utility Navigation Block'
+revision: 0
+description: 'Block of static HTML representing the utility navigation menu.'

--- a/web/modules/custom/utility_nav/config/install/core.entity_form_display.block_content.utility_navigation_block.default.yml
+++ b/web/modules/custom/utility_nav/config/install/core.entity_form_display.block_content.utility_navigation_block.default.yml
@@ -1,0 +1,39 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - block_content.type.utility_navigation_block
+    - field.field.block_content.utility_navigation_block.body
+  module:
+    - text
+id: block_content.utility_navigation_block.default
+targetEntityType: block_content
+bundle: utility_navigation_block
+mode: default
+content:
+  body:
+    type: text_textarea_with_summary
+    weight: 26
+    settings:
+      rows: 9
+      summary_rows: 3
+      placeholder: ''
+      show_summary: false
+    third_party_settings: {  }
+    region: content
+  info:
+    type: string_textfield
+    weight: -5
+    region: content
+    settings:
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+  langcode:
+    type: language_select
+    weight: 2
+    region: content
+    settings:
+      include_locked: true
+    third_party_settings: {  }
+hidden: {  }

--- a/web/modules/custom/utility_nav/config/install/core.entity_view_display.block_content.utility_navigation_block.default.yml
+++ b/web/modules/custom/utility_nav/config/install/core.entity_view_display.block_content.utility_navigation_block.default.yml
@@ -1,0 +1,23 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - block_content.type.utility_navigation_block
+    - field.field.block_content.utility_navigation_block.body
+  module:
+    - text
+id: block_content.utility_navigation_block.default
+targetEntityType: block_content
+bundle: utility_navigation_block
+mode: default
+content:
+  body:
+    label: hidden
+    type: text_default
+    weight: 0
+    settings: {  }
+    third_party_settings: {  }
+    region: content
+hidden:
+  langcode: true
+  search_api_excerpt: true

--- a/web/modules/custom/utility_nav/config/install/field.field.block_content.utility_navigation_block.body.yml
+++ b/web/modules/custom/utility_nav/config/install/field.field.block_content.utility_navigation_block.body.yml
@@ -6,6 +6,8 @@ dependencies:
     - field.storage.block_content.body
   module:
     - text
+_core:
+  default_config_hash: Ef2E3eHsEZWxZ5JNpsHIewKTDiRv30zP8UnwMzdbD_g
 id: block_content.utility_navigation_block.body
 field_name: body
 entity_type: block_content
@@ -17,7 +19,7 @@ translatable: true
 default_value:
   -
     summary: ''
-    value: "<ul>\r\n  <li><span class=\"fas fa-clock\"></span> <a class=\"umd-utility-nav-locations\" href=\"/locations\">Locations &amp; Hours</a></li>\r\n  <li><span class=\"fas fa-exclamation-triangle\"></span> <a class=\"umd-utility-nav-status\" href=\"/about/systems\">Systems Status</a></li>\r\n  <li><span class=\"fas fa-question-circle\"></span> <a class=\"umd-utility-nav-help\" href=\"/help\">Get Help</a></li>\r\n  <li><span class=\"fas fa-info-circle\"></span> <a class=\"umd-utility-nav-info\" href=\"/info\">Info For</a></li>\r\n  <li><span class=\"fas fa-user\"></span> <a class=\"umd-utility-nav-accounts\" href=\"/accounts\">My Accounts</a></li>\r\n</ul>\r\n"
+    value: "<h2 class=\"visually-hidden\" id=\"block-utilitynavigation-menu\">Utility Navigation</h2>\r\n<ul class=\"utility-menus\">\r\n  <li>\r\n    <a href=\"/locations\"><span class=\"fas fa-clock\"></span><br />\r\n    <span class=\"utility-label utility-nav-locations\">Locations &amp; Hours</span></a>\r\n  </li>\r\n  <li>\r\n    <a href=\"/about/systems\"><span class=\"fas fa-exclamation-triangle\"></span><br />\r\n    <span class=\"utility-label utility-nav-systems-status\">Systems Status</span></a>\r\n  </li>\r\n  <li>\r\n    <a href=\"/help\"><span class=\"fas fa-question-circle\"></span><br />\r\n    <span class=\"utility-label utility-nav-help\">Get Help<br/>&nbsp;</span></a>\r\n  </li>\r\n  <li>\r\n    <a href=\"/info\"><span class=\"fas fa-info-circle\"></span><br />\r\n    <span class=\"utility-label utility-nav-info\">Info For<br/>&nbsp;</span></a>\r\n  </li>\r\n  <li>\r\n    <a href=\"/accounts\"><span class=\"fas fa-user\"></span><br />\r\n    <span class=\"utility-label utility-nav-accounts\">My Accounts<br/>&nbsp;</span></a>\r\n  </li>\r\n</ul>"
     format: full_html
 default_value_callback: ''
 settings:

--- a/web/modules/custom/utility_nav/config/install/field.field.block_content.utility_navigation_block.body.yml
+++ b/web/modules/custom/utility_nav/config/install/field.field.block_content.utility_navigation_block.body.yml
@@ -17,7 +17,7 @@ translatable: true
 default_value:
   -
     summary: ''
-    value: "<ul>\r\n  <li><span class=\"fas fa-clock\"></span> <a class=\"umd-utility-nav-locations\" data-drupal-link-system-path=\"node/209\" href=\"/locations\">Locations &amp; Hours</a></li>\r\n  <li><span class=\"fas fa-exclamation-triangle\"></span> <a class=\"umd-utility-nav-status\" data-drupal-link-system-path=\"node/36\" href=\"/about/systems\">Systems Status</a></li>\r\n  <li><span class=\"fas fa-question-circle\"></span> <a class=\"umd-utility-nav-help\" data-drupal-link-system-path=\"node/274\" href=\"/help\">Get Help</a></li>\r\n  <li><span class=\"fas fa-info-circle\"></span> <a class=\"umd-utility-nav-info\" data-drupal-link-system-path=\"node/211\" href=\"/info\">Info For</a></li>\r\n  <li><span class=\"fas fa-user\"></span> <a class=\"umd-utility-nav-accounts\" data-drupal-link-system-path=\"node/210\" href=\"/accounts\">My Accounts</a></li>\r\n</ul>\r\n"
+    value: "<ul>\r\n  <li><span class=\"fas fa-clock\"></span> <a class=\"umd-utility-nav-locations\" href=\"/locations\">Locations &amp; Hours</a></li>\r\n  <li><span class=\"fas fa-exclamation-triangle\"></span> <a class=\"umd-utility-nav-status\" href=\"/about/systems\">Systems Status</a></li>\r\n  <li><span class=\"fas fa-question-circle\"></span> <a class=\"umd-utility-nav-help\" href=\"/help\">Get Help</a></li>\r\n  <li><span class=\"fas fa-info-circle\"></span> <a class=\"umd-utility-nav-info\" href=\"/info\">Info For</a></li>\r\n  <li><span class=\"fas fa-user\"></span> <a class=\"umd-utility-nav-accounts\" href=\"/accounts\">My Accounts</a></li>\r\n</ul>\r\n"
     format: full_html
 default_value_callback: ''
 settings:

--- a/web/modules/custom/utility_nav/config/install/field.field.block_content.utility_navigation_block.body.yml
+++ b/web/modules/custom/utility_nav/config/install/field.field.block_content.utility_navigation_block.body.yml
@@ -1,0 +1,26 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - block_content.type.utility_navigation_block
+    - field.storage.block_content.body
+  module:
+    - text
+id: block_content.utility_navigation_block.body
+field_name: body
+entity_type: block_content
+bundle: utility_navigation_block
+label: Body
+description: ''
+required: false
+translatable: true
+default_value:
+  -
+    summary: ''
+    value: "<ul>\r\n  <li><span class=\"fas fa-clock\"></span> <a class=\"umd-utility-nav-locations\" data-drupal-link-system-path=\"node/209\" href=\"/locations\">Locations &amp; Hours</a></li>\r\n  <li><span class=\"fas fa-exclamation-triangle\"></span> <a class=\"umd-utility-nav-status\" data-drupal-link-system-path=\"node/36\" href=\"/about/systems\">Systems Status</a></li>\r\n  <li><span class=\"fas fa-question-circle\"></span> <a class=\"umd-utility-nav-help\" data-drupal-link-system-path=\"node/274\" href=\"/help\">Get Help</a></li>\r\n  <li><span class=\"fas fa-info-circle\"></span> <a class=\"umd-utility-nav-info\" data-drupal-link-system-path=\"node/211\" href=\"/info\">Info For</a></li>\r\n  <li><span class=\"fas fa-user\"></span> <a class=\"umd-utility-nav-accounts\" data-drupal-link-system-path=\"node/210\" href=\"/accounts\">My Accounts</a></li>\r\n</ul>\r\n"
+    format: full_html
+default_value_callback: ''
+settings:
+  display_summary: false
+  required_summary: false
+field_type: text_with_summary

--- a/web/modules/custom/utility_nav/config/install/fixed_block_content.fixed_block_content.utility_navigation_fixed_block.yml
+++ b/web/modules/custom/utility_nav/config/install/fixed_block_content.fixed_block_content.utility_navigation_fixed_block.yml
@@ -1,0 +1,11 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - block_content.type.utility_navigation_block
+id: utility_navigation_fixed_block
+title: 'Utility Navigation Fixed Block'
+block_content_bundle: utility_navigation_block
+default_content: null
+auto_export: 1
+protected: false

--- a/web/modules/custom/utility_nav/css/utility-nav.css
+++ b/web/modules/custom/utility_nav/css/utility-nav.css
@@ -1,0 +1,35 @@
+/* CSS Document for Utility Menus */
+
+.site-header__logo img {
+  height: auto;
+  width: 250px;
+}
+.site-header__bar {
+  margin-bottom: 1rem;
+}
+nav#block-utilitynavigation{
+  float: right;
+}
+.site-header__nav, .site-header__nav>ul{
+  float: right;
+}
+ul.utility-menus > li {
+  display: inline-block;
+  text-align: center;
+  line-height: 1.5rem;
+  border-left: 2px #eee solid;
+  padding: 0 0.5rem;
+  margin: 1rem 0;
+  text-transform: uppercase;
+  max-width: 110px;
+  vertical-align: top;
+}
+.fa-big {
+  font-size: 1.3rem;
+}
+.utility-icon {
+  padding: 0.2rem 2rem;
+}
+.utility-label {
+  font-size: 0.8rem;
+}

--- a/web/modules/custom/utility_nav/utility_nav.info.yml
+++ b/web/modules/custom/utility_nav/utility_nav.info.yml
@@ -1,0 +1,10 @@
+name: Utility Nav
+description: Provides a static utility navigation bar
+
+package: 'UMD Services'
+type: module
+dependencies:
+  - drupal:easy_install
+  - drupal:fixed_block_content
+
+core_version_requirement: ^8.9 || ^9

--- a/web/modules/custom/utility_nav/utility_nav.libraries.yml
+++ b/web/modules/custom/utility_nav/utility_nav.libraries.yml
@@ -1,0 +1,5 @@
+utility-nav:
+  version: 1.x
+  css:
+    theme:
+      css/utility-nav.css: {}

--- a/web/modules/custom/utility_nav/utility_nav.module
+++ b/web/modules/custom/utility_nav/utility_nav.module
@@ -1,0 +1,6 @@
+<?php
+
+/**
+ * @file
+ * Module file for the utility_nav module.
+ */

--- a/web/modules/custom/utility_nav/utility_nav.module
+++ b/web/modules/custom/utility_nav/utility_nav.module
@@ -4,3 +4,12 @@
  * @file
  * Module file for the utility_nav module.
  */
+
+/**
+ * @param $variables
+ */
+function utility_nav_preprocess_page(&$variables)
+{
+  // Add CSS
+  $variables['#attached']['library'][] = 'utility_nav/utility-nav';
+}

--- a/web/themes/frozen/umd_terp/templates/_includes/global/header.html.twig
+++ b/web/themes/frozen/umd_terp/templates/_includes/global/header.html.twig
@@ -17,7 +17,6 @@
 		{{ 'Skip to main content'|t }}
 	</a>
 	<div class="max-bound">
-		{{ page.main_menu }}
 	</div>
 	<div class="site-header__bar max-bound">
 		<a class="site-header__logo" href="{{ path('<front>') }}">
@@ -29,17 +28,22 @@
 				</span>
 			{% endif %}
 		</a>
-		<a href="#site-header-nav" class="site-header__nav-toggle" id="site-header-nav-toggle" tabindex="0" role="button" aria-label="Main Menu" aria-controls="site-header-nav">
-			<span aria-hidden="true" class="site-header__nav-icon">
-				<span role="presentation"></span>
-				<span role="presentation"></span>
-				<span role="presentation"></span>
-				<span role="presentation"></span>
-			</span>
-			<span class="sr-only">Main Menu</span>
-		</a>
-		<nav class="site-header__nav" id="site-header-nav" aria-labelledby="site-header-nav-toggle">
-			{{ drupal_menu('main', 1, 2, TRUE) }}
-		</nav>
+    <div class="navigations">
+      <nav role="navigation" aria-labelledby="block-utilitynavigation-menu" id="block-utilitynavigation">
+    		{{ page.main_menu }}
+      </nav>
+		  <a href="#site-header-nav" class="site-header__nav-toggle" id="site-header-nav-toggle" tabindex="0" role="button" aria-label="Main Menu" aria-controls="site-header-nav">
+			  <span aria-hidden="true" class="site-header__nav-icon">
+				  <span role="presentation"></span>
+				  <span role="presentation"></span>
+				  <span role="presentation"></span>
+				  <span role="presentation"></span>
+			  </span>
+			  <span class="sr-only">Main Menu</span>
+		  </a>
+		  <nav class="site-header__nav" id="site-header-nav" aria-labelledby="site-header-nav-toggle">
+			  {{ drupal_menu('main', 1, 2, TRUE) }}
+		  </nav>
+    </div>
 	</div>
 </header>


### PR DESCRIPTION
Implemented the "utility nav" bar, with JavaScript functionality to retrieve
the count of non-operational systems for the "Systems Status" item.

The JavaScript for retrieving the systems status is in the "system_status" module.

The "utility nav" bar display is handled by the "utility_nav" module. The
"fixed_content_block" module (https://www.drupal.org/project/fixed_block_content)
was used, instead of the Drupal menu functionality,  as it seems to provide a
simpler and more flexible way to specify the HTML for the bar. The
"fixed_content_block" module enables the HTML for the utility nav bar to
be specified in Drupal YAML configuation files.

The appearance of the utility nav bar is based on the mockup at

https://mockups.sandbox.lib.umd.edu/wwwnew/utility.html

https://issues.umd.edu/browse/LIBWEB-5389