### PR TITLE
LIBWEB-5441. "Advanced Search" in hero search should appear only for WorldCat

### DIFF
--- a/web/modules/custom/hero_search/README.md
+++ b/web/modules/custom/hero_search/README.md
@@ -6,7 +6,8 @@ This module adds the configurable custom search block for use in home page.
 
 Enable the "Hero Search" module in "Manage | Extend"
 
-After the module is installed, the "Hero Search" block can be placed in the home page [Hero Block](../hero_block) region.
+After the module is installed, the "Hero Search" block can be placed in the home
+page [Hero Block](../hero_block) region.
 
 ## Theming
 
@@ -14,4 +15,44 @@ css/hero-search.css is provided for theming the hero_search custom block.
 
 ## Config
 
-The configuration for the search target URLs will be available in the "Drupal Configuration" page > "SEARCH AND METADATA" section > "Hero Search" (/admin/config/search/hero_search).
+The configuration for the search target URLs will be available in the
+"Drupal Configuration" page > "SEARCH AND METADATA" section > "Hero Search"
+(/admin/config/search/hero_search).
+
+The "Search Targets" use a YAML format to specify that names and URLs of the
+search targets, as well as an optional "alternate" search target.
+
+The YAML format is the following:
+
+```
+<SEARCH_TARGET_NAME>:
+  url: '<URL>'
+  alternate: { url: '<ALTERNATE_URL>', text: 'ALTERNATE_LINK_TEXT', title: 'ALTERNATE_TOOLTIP_TEXT' }
+```
+
+where:
+
+* SEARCH_TARGET_NAME - the name of the option in the search dialog
+    (i.e., "All", "UMD Catalog", "WorldCat")
+* URL - the URL to use in performing the search. URLs are expected to end with
+    a "=" to allow the query term to be appended.
+* ALTERNATE_URL - the URL to use as an "alternate" search, such as a direct link
+    to a vendor search page.
+* ALTERNATE_LINK_TEXT - The text to display for the link
+* ALTERNATE_TOOLTIP_TEXT - The tooltip to display when hovering over the link.
+
+Sample configuration:
+
+```
+All:
+    url: 'https://searchnew.lib.umd.edu/results?search&query='
+'UMD Catalog':
+    url: 'https://catalog.umd.edu/cgi-bin/direct?searchtype=F1_WRD&base=CP&search=&searchrequest='
+WorldCat:
+    url: 'https://umaryland.on.worldcat.org/search?databaseList=&umdlib=&queryString='
+    alternate: { url: 'https://umaryland.on.worldcat.org/advancedsearch', text: 'Advanced Search', title: tooltip }
+```
+
+Provides three search option, "All", "UMD Catalog", and "WorldCat".
+When the "WorldCat" option is selected in the GUI, the "alternate" link will
+also be displayed.

--- a/web/modules/custom/hero_search/config/install/hero_search.settings.yml
+++ b/web/modules/custom/hero_search/config/install/hero_search.settings.yml
@@ -1,0 +1,30 @@
+title: Search
+placeholder: 'SEARCH BOOKS, JOURNALS, ARTICLE, MEDIA'
+search_targets:
+  All: 'https://searchnew.lib.umd.edu/results?search&query='
+  'UMD Catalog': 'https://catalog.umd.edu/cgi-bin/direct?searchtype=F1_WRD&base=CP&search=&searchrequest='
+  WorldCat: 'https://umaryland.on.worldcat.org/search?databaseList=&umdlib=&queryString='
+button1_url: 'https://lib.guides.umd.edu/az.php'
+button1_text: DATABASES
+button1_title: DATABASES
+button2_url: 'https://lib.guides.umd.edu/srch.php'
+button2_text: 'RESEARCH GUIDES'
+button2_title: 'RESEARCH GUIDES'
+button3_url: 'https://umd.libanswers.com/search'
+button3_text: FAQs
+button3_title: FAQs
+button4_url: 'https://searchnew.lib.umd.edu/website'
+button4_text: WEBSITE
+button4_title: WEBSITE
+advanced_search_url: 'https://umaryland.on.worldcat.org/advancedsearch'
+advanced_search_text: 'Advanced Search'
+advanced_search_title: 'Advanced Search'
+top_right_link_url: ''
+top_right_link_text: ''
+top_right_link_title: ''
+bottom_left_link_url: 'https://searchnew.lib.umd.edu/'
+bottom_left_link_text: 'Learn more about search at the University Libraries'
+bottom_left_link_title: 'Learn more about search at the University Libraries'
+bottom_right_link_url: 'https://www.lib.umd.edu/suggestions'
+bottom_right_link_text: Feedback
+bottom_right_link_title: Feedback

--- a/web/modules/custom/hero_search/css/hero-search.css
+++ b/web/modules/custom/hero_search/css/hero-search.css
@@ -19,16 +19,19 @@
   font-size: 1rem;
 }
 
-.darklinks, .darklinks a{
+.darklinks,
+.darklinks a {
   color: #333;
   text-decoration: underline;
   font-size: 0.912rem;
 }
 
-input[type=text], select, textarea {
+input[type=text],
+select,
+textarea {
   width: 100%;
   padding: 12px;
-} 
+}
 .hero-search-input > input#edit-submit {
   background: #e21833;
   color: #fff!important;
@@ -43,7 +46,8 @@ input[type=text], select, textarea {
   margin-right: 2rem;
   margin-bottom: 0;
 }
-.home-hero.home-hero-bg .btn, .home-hero.home-hero-dark .btn {
+.home-hero.home-hero-bg .btn,
+.home-hero.home-hero-dark .btn {
   color: #000!important;
   border-color: #c8c8c8!important;
   font-weight: 400;
@@ -74,18 +78,15 @@ input[type=text], select, textarea {
 }
 
 @media (min-width: 1000px) {
-.hero-block {
-  margin-left: 12rem!important;
-}
-
-.form-actions, .form-item {
-}
+  .hero-block {
+    margin-left: 12rem!important;
+  }
 }
 
 @media (max-width: 768px) {
-.hero-block {
-  margin-left: 0!important;
-  border: 1px solid #ccc;
-  padding:  1rem;
-}
+  .hero-block {
+    margin-left: 0!important;
+    border: 1px solid #ccc;
+    padding: 1rem;
+  }
 }

--- a/web/modules/custom/hero_search/hero_search.info.yml
+++ b/web/modules/custom/hero_search/hero_search.info.yml
@@ -5,7 +5,7 @@ package: 'UMD Services'
 configure: hero_search.admin_settings_form
 type: module
 dependencies:
-  - easy_install
-  - libraries_configuration
+  - drupal:easy_install
+  - libraries_configuration:libraries_configuration
 
 core_version_requirement: ^8.8 || ^9

--- a/web/modules/custom/hero_search/hero_search.install
+++ b/web/modules/custom/hero_search/hero_search.install
@@ -13,6 +13,41 @@ function hero_search_update_8001() {
 }
 
 /**
+ * LIBWEB-5441 - Replaces "Advanced Search" with "alternate search".
+ */
+function hero_search_update_8002() {
+  $config_factory = \Drupal::configFactory();
+  $hero_search_settings = $config_factory->getEditable('hero_search.settings');
+  \Drupal::logger('hero_search')->notice("Running hero_search_update_8002");
+
+  // Replace existing "search_targets" with updated YAML configuration
+  $hero_search_settings->set('search_targets',
+      [
+        "All" => [
+          "url" => "https://foobar.lib.umd.edu/results?search&query=",
+        ],
+        "UMD Catalog" => [
+          "url" => "https://catalog.umd.edu/cgi-bin/direct?searchtype=F1_WRD&base=CP&search=&searchrequest=",
+        ],
+        "WorldCat" => [
+          "url" => "https://umaryland.on.worldcat.org/search?databaseList=&umdlib=&queryString=",
+          "alternate" => [
+            "url" => "https://umaryland.on.worldcat.org/advancedsearch",
+            "text" => "Advanced Search",
+            "title" => "Advanced Search",
+          ],
+        ],
+      ]
+  );
+
+  // Remove obsolete "advanced_search" settings
+  $hero_search_settings->clear('advanced_search_url');
+  $hero_search_settings->clear('advanced_search_text');
+  $hero_search_settings->clear('advanced_search_title');
+  $hero_search_settings->save();
+}
+
+/**
  * Implements hook_uninstall
  */
 function hero_search_uninstall() {

--- a/web/modules/custom/hero_search/hero_search.install
+++ b/web/modules/custom/hero_search/hero_search.install
@@ -18,7 +18,6 @@ function hero_search_update_8001() {
 function hero_search_update_8002() {
   $config_factory = \Drupal::configFactory();
   $hero_search_settings = $config_factory->getEditable('hero_search.settings');
-  \Drupal::logger('hero_search')->notice("Running hero_search_update_8002");
 
   // Replace existing "search_targets" with updated YAML configuration.
   $hero_search_settings->set('search_targets',

--- a/web/modules/custom/hero_search/hero_search.install
+++ b/web/modules/custom/hero_search/hero_search.install
@@ -20,7 +20,7 @@ function hero_search_update_8002() {
   $hero_search_settings = $config_factory->getEditable('hero_search.settings');
   \Drupal::logger('hero_search')->notice("Running hero_search_update_8002");
 
-  // Replace existing "search_targets" with updated YAML configuration
+  // Replace existing "search_targets" with updated YAML configuration.
   $hero_search_settings->set('search_targets',
       [
         "All" => [
@@ -40,15 +40,9 @@ function hero_search_update_8002() {
       ]
   );
 
-  // Remove obsolete "advanced_search" settings
+  // Remove obsolete "advanced_search" settings.
   $hero_search_settings->clear('advanced_search_url');
   $hero_search_settings->clear('advanced_search_text');
   $hero_search_settings->clear('advanced_search_title');
   $hero_search_settings->save();
-}
-
-/**
- * Implements hook_uninstall
- */
-function hero_search_uninstall() {
 }

--- a/web/modules/custom/hero_search/hero_search.links.menu.yml
+++ b/web/modules/custom/hero_search/hero_search.links.menu.yml
@@ -1,6 +1,0 @@
-hero_search.admin_settings_form:
-  title: 'Libraries Search (Hero)'
-  description: 'Configuration of the Libraries search.'
-  parent: 'system.admin_config_search'
-  weight: 90
-  route_name: hero_search.admin_settings_form

--- a/web/modules/custom/hero_search/hero_search.links.task.yml
+++ b/web/modules/custom/hero_search/hero_search.links.task.yml
@@ -1,5 +1,5 @@
 hero_search.hero_search_tab:
   title: 'Hero Search'
   route_name: hero_search.admin_settings_form
-  base_route: hero_search.admin_settings_form
+  base_route: libraries_configuration.base_tab
   weight: 99

--- a/web/modules/custom/hero_search/hero_search.module
+++ b/web/modules/custom/hero_search/hero_search.module
@@ -1,10 +1,11 @@
 <?php
+
 /**
  * @file
- * Module file for the hero_search module
+ * Module file for the hero_search module.
  */
 
- /**
+/**
  * Implements hook_theme().
  */
 function hero_search_theme() {

--- a/web/modules/custom/hero_search/src/Form/HeroSearchForm.php
+++ b/web/modules/custom/hero_search/src/Form/HeroSearchForm.php
@@ -11,14 +11,30 @@ use Drupal\hero_search\Helper\HeroSearchSettingsHelper;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 
 /**
- * Implement HeroSearchForm
+ * Implements search box displayed atop a hero image.
  */
 class HeroSearchForm extends FormBase {
 
+  /**
+   * The logger instance.
+   *
+   * @var Drupal\Core\Logger\LoggerChannelInterface
+   */
   protected $logger;
 
+  /**
+   * The HeroSearchSettingsHelper instance.
+   *
+   * @var Drupal\hero_search\Helper\HeroSearchSettingsHelper
+   */
   protected $configHelper;
 
+  /**
+   * Constructor.
+   *
+   * @param Drupal\Core\Logger\LoggerChannelInterface $logger
+   *   The logger instance.
+   */
   public function __construct(LoggerChannelInterface $logger) {
     $this->logger = $logger;
     $this->configHelper = HeroSearchSettingsHelper::getInstance();

--- a/web/modules/custom/hero_search/src/Form/HeroSearchForm.php
+++ b/web/modules/custom/hero_search/src/Form/HeroSearchForm.php
@@ -4,19 +4,35 @@ namespace Drupal\hero_search\Form;
 
 use Drupal\Core\Form\FormBase;
 use Drupal\Core\Form\FormStateInterface;
+use Drupal\Core\Logger\LoggerChannelInterface;
 use Drupal\Core\Routing\TrustedRedirectResponse;
 use Drupal\Core\Url;
 use Drupal\hero_search\Helper\HeroSearchSettingsHelper;
+use Symfony\Component\DependencyInjection\ContainerInterface;
 
 /**
  * Implement HeroSearchForm
  */
 class HeroSearchForm extends FormBase {
 
+  protected $logger;
+
   protected $configHelper;
 
-  public function __construct() {
+  public function __construct(LoggerChannelInterface $logger) {
+    $this->logger = $logger;
     $this->configHelper = HeroSearchSettingsHelper::getInstance();
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function create(ContainerInterface $container) {
+    // Instantiates this form class.
+    return new static(
+      // Load the service required to construct this class.
+      $container->get('logger.channel.hero_search')
+    );
   }
 
   /**
@@ -91,7 +107,7 @@ class HeroSearchForm extends FormBase {
     $target_base_url = $this->configHelper->getSearchTargetUrl($target);
     $url = '/';
     if ($target_base_url == NULL) {
-      \Drupal::logger('hero_search')->notice("The base search Url configuration for '$target' is missing!");
+      $this->logger->notice("The base search Url configuration for '$target' is missing!");
     }
     else {
       $url = Url::fromUri($target_base_url . $query)->toString();

--- a/web/modules/custom/hero_search/src/Form/HeroSearchForm.php
+++ b/web/modules/custom/hero_search/src/Form/HeroSearchForm.php
@@ -1,8 +1,4 @@
 <?php
-/**
- * @file
- * Definition of HeroSearchForm
- */
 
 namespace Drupal\hero_search\Form;
 
@@ -14,7 +10,7 @@ use Drupal\hero_search\Helper\HeroSearchSettingsHelper;
 
 /**
  * Implement HeroSearchForm
-*/
+ */
 class HeroSearchForm extends FormBase {
 
   protected $configHelper;
@@ -25,14 +21,14 @@ class HeroSearchForm extends FormBase {
 
   /**
    * {@inheritdoc}
-  */
+   */
   public function getFormId() {
     return 'hero_search_form';
   }
 
   /**
    * {@inheritdoc}
-  */
+   */
   public function buildForm(array $form, FormStateInterface $form_state) {
     $form['search_query'] = [
       '#type' => 'textfield',
@@ -42,12 +38,12 @@ class HeroSearchForm extends FormBase {
       '#maxlength' => 60,
       '#required' => TRUE,
     ];
-    $form['search_target'] = array(
+    $form['search_target'] = [
       '#type' => 'radios',
       '#name' => 'search_target',
       '#default_value' => array_key_first($this->configHelper->getSearchTargetOptions()),
       '#options' => $this->configHelper->getSearchTargetOptions(),
-    );
+    ];
     $alternate_searches = $this->configHelper->getAlternateSearches();
 
     foreach ($alternate_searches as $alternate_search) {
@@ -59,13 +55,13 @@ class HeroSearchForm extends FormBase {
         '#type' => 'item',
         '#markup' => "<a href='{$url}' title='{$this->t($title)}'>{$this->t($text)}</a>",
         '#attributes' => [
-           'id' => $id,
-         ],
+          'id' => $id,
+        ],
         '#states' => [
           'visible' => [
             ':input[name="search_target"]' => ['value' => $alternate_search['search_target']],
           ],
-        ]
+        ],
       ];
     }
 
@@ -81,25 +77,27 @@ class HeroSearchForm extends FormBase {
 
   /**
    * {@inheritdoc}
-  */
+   */
   public function validateForm(array &$form, FormStateInterface $form_state) {
     // Nothing.
   }
 
   /**
    * {@inheritdoc}
-  */
+   */
   public function submitForm(array &$form, FormStateInterface $form_state) {
     $query = $form_state->getValue('search_query');
     $target = $form_state->getValue('search_target');
     $target_base_url = $this->configHelper->getSearchTargetUrl($target);
     $url = '/';
-    if ($target_base_url == null) {
+    if ($target_base_url == NULL) {
       \Drupal::logger('hero_search')->notice("The base search Url configuration for '$target' is missing!");
-    } else {
+    }
+    else {
       $url = Url::fromUri($target_base_url . $query)->toString();
     }
     $response = new TrustedRedirectResponse($url);
     $form_state->setResponse($response);
   }
+
 }

--- a/web/modules/custom/hero_search/src/Form/HeroSearchForm.php
+++ b/web/modules/custom/hero_search/src/Form/HeroSearchForm.php
@@ -48,20 +48,33 @@ class HeroSearchForm extends FormBase {
       '#default_value' => array_key_first($this->configHelper->getSearchTargetOptions()),
       '#options' => $this->configHelper->getSearchTargetOptions(),
     );
-    $adv_search_link = $this->configHelper->getLinkField('advanced_search');
-    if ($adv_search_link != null) {
-      $form['advanced_search'] = [
-        '#type' => 'markup',
-        '#markup' => "<a href='{$adv_search_link['url']}' title='{$this->t($adv_search_link['title'])}'>{$this->t($adv_search_link['text'])}</a>",
-        '#url' => $adv_search_link['url'],
+    $alternate_searches = $this->configHelper->getAlternateSearches();
+
+    foreach ($alternate_searches as $alternate_search) {
+      $id = 'alternate_search_' . $alternate_search['search_target'];
+      $url = $alternate_search['url'];
+      $title = $alternate_search['title'];
+      $text = $alternate_search['text'];
+      $form['alternate_search'][] = [
+        '#type' => 'item',
+        '#markup' => "<a href='{$url}' title='{$this->t($title)}'>{$this->t($text)}</a>",
+        '#attributes' => [
+           'id' => $id,
+         ],
+        '#states' => [
+          'visible' => [
+            ':input[name="search_target"]' => ['value' => $alternate_search['search_target']],
+          ],
+        ]
       ];
     }
+
     $form['actions']['#type'] = 'actions';
     $form['actions']['submit'] = [
       '#type' => 'submit',
       '#value' => $this->t('Search'),
     ];
-   
+
     $form['#theme'] = 'hero_search_form';
     return $form;
   }

--- a/web/modules/custom/hero_search/src/Form/HeroSearchSettingsForm.php
+++ b/web/modules/custom/hero_search/src/Form/HeroSearchSettingsForm.php
@@ -4,10 +4,11 @@ namespace Drupal\hero_search\Form;
 
 use Drupal\Core\Form\ConfigFormBase;
 use Drupal\Core\Form\FormStateInterface;
-
+use Drupal\Core\Logger\LoggerChannelInterface;
 use Drupal\hero_search\Helper\HeroSearchSettingsHelper;
 use Symfony\Component\Yaml\Yaml;
 use Symfony\Component\Yaml\Exception\ParseException;
+use Symfony\Component\DependencyInjection\ContainerInterface;
 
 /**
  * Settings for Hero Search target urls.
@@ -18,10 +19,23 @@ class HeroSearchSettingsForm extends ConfigFormBase {
 
   const SETTINGS = 'hero_search.settings';
 
+  protected $logger;
+
   protected $configHelper;
 
-  public function __construct() {
+
+  public function __construct(LoggerChannelInterface $logger) {
+    $this->logger = $logger;
     $this->configHelper = HeroSearchSettingsHelper::getInstance();
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function create(ContainerInterface $container) {
+    return new static(
+      $container->get('logger.channel.hero_search')
+    );
   }
 
   /**
@@ -179,7 +193,7 @@ class HeroSearchSettingsForm extends ConfigFormBase {
     catch (ParseException $pe) {
       // Shouldn't happen, because invalid YAML should be caught by
       // "validateForm" method.
-      \Drupal::logger('hero_search')->error("Error parsing 'Search Targets' YAML: " . $pe);
+      $this->logger('hero_search')->error("Error parsing 'Search Targets' YAML: " . $pe);
     }
 
     foreach (HeroSearchSettingsHelper::LINK_FIELDS as $name => $title) {

--- a/web/modules/custom/hero_search/src/Form/HeroSearchSettingsForm.php
+++ b/web/modules/custom/hero_search/src/Form/HeroSearchSettingsForm.php
@@ -19,11 +19,26 @@ class HeroSearchSettingsForm extends ConfigFormBase {
 
   const SETTINGS = 'hero_search.settings';
 
+  /**
+   * The logger instance.
+   *
+   * @var Drupal\Core\Logger\LoggerChannelInterface
+   */
   protected $logger;
 
+  /**
+   * The HeroSearchSettingsHelper instance.
+   *
+   * @var Drupal\hero_search\Helper\HeroSearchSettingsHelper
+   */
   protected $configHelper;
 
-
+  /**
+   * Constructor.
+   *
+   * @param Drupal\Core\Logger\LoggerChannelInterface $logger
+   *   The logger instance.
+   */
   public function __construct(LoggerChannelInterface $logger) {
     $this->logger = $logger;
     $this->configHelper = HeroSearchSettingsHelper::getInstance();

--- a/web/modules/custom/hero_search/src/Helper/HeroSearchSettingsHelper.php
+++ b/web/modules/custom/hero_search/src/Helper/HeroSearchSettingsHelper.php
@@ -1,16 +1,9 @@
 <?php
 
-/**
- * @file
- * Definition of Drupal\hero_search\Controller\HeroSearchSettingsHelper
- */
-
 namespace Drupal\hero_search\Helper;
 
-use Symfony\Component\Yaml\Yaml;
-
 /**
- * Helper class for retrieving search target settings
+ * Helper class for retrieving search target settings.
  */
 class HeroSearchSettingsHelper {
 
@@ -32,10 +25,8 @@ class HeroSearchSettingsHelper {
     $this->config = \Drupal::config('hero_search.settings');
   }
 
-  public static function getInstance()
-  {
-    if ( is_null( self::$instance ) )
-    {
+  public static function getInstance() {
+    if (is_null(self::$instance)) {
       self::$instance = new self();
     }
     return self::$instance;
@@ -61,7 +52,7 @@ class HeroSearchSettingsHelper {
 
   public function getLinkField($name) {
     $url = $this->config->get($name . '_url');
-    return $url == null ? null : [
+    return $url == NULL ? NULL : [
       'url' => $url,
       'text' => $this->config->get($name . '_text'),
       'title' => $this->config->get($name . '_title'),
@@ -69,7 +60,7 @@ class HeroSearchSettingsHelper {
   }
 
   public function getAlternateSearches() {
-    $search_targets =$this->config->get('search_targets');
+    $search_targets = $this->config->get('search_targets');
     $alternate_searches = [];
     foreach ($search_targets as $search_target => $val) {
       $has_alternate = isset($val['alternate']);
@@ -80,4 +71,5 @@ class HeroSearchSettingsHelper {
     }
     return $alternate_searches;
   }
+
 }

--- a/web/modules/custom/hero_search/src/Helper/HeroSearchSettingsHelper.php
+++ b/web/modules/custom/hero_search/src/Helper/HeroSearchSettingsHelper.php
@@ -7,6 +7,8 @@
 
 namespace Drupal\hero_search\Helper;
 
+use Symfony\Component\Yaml\Yaml;
+
 /**
  * Helper class for retrieving search target settings
  */
@@ -17,7 +19,6 @@ class HeroSearchSettingsHelper {
     'button2' => 'Button 2',
     'button3' => 'Button 3',
     'button4' => 'Button 4',
-    'advanced_search' => 'Advanced Search',
     'top_right_link' => 'Top Right Link',
     'bottom_left_link' => 'Bottom Left Link',
     'bottom_right_link' => 'Bottom Right Link',
@@ -40,40 +41,6 @@ class HeroSearchSettingsHelper {
     return self::$instance;
   }
 
-  // 
-  public function parseSearchTargets($multiline_str) {
-    $values = [];
-
-    $list = explode("\n", $multiline_str);
-    $list = array_map('trim', $list);
-    $list = array_filter($list, 'strlen');
-
-    foreach ($list as $position => $text) {
-      // Check for an explicit key.
-      $matches = [];
-      if (preg_match('/(.*)\|(.*)/', $text, $matches)) {
-        // Trim key and value to avoid unwanted spaces issues.
-        $key = trim($matches[1]);
-        $value = trim($matches[2]);
-      }
-      else {
-        return;
-      }
-
-      $values[$key] = $value;
-    }
-
-    return $values;
-  }
-
-  public function convertSearchTargetsToString($targets) {
-    $target_str = '';
-    foreach($targets as $name => $url) {
-      $target_str = $target_str . "$name|$url\n";
-    }
-    return $target_str;
-  }
-
   public function getSearchTargetOptions() {
     $target_names = array_keys($this->config->get('search_targets'));
     return array_combine($target_names, $target_names);
@@ -81,7 +48,7 @@ class HeroSearchSettingsHelper {
 
   public function getSearchTargetUrl($target) {
     $targets = $this->config->get('search_targets');
-    return $targets[$target];
+    return $targets[$target]['url'];
   }
 
   public function getSearchTitle() {
@@ -99,5 +66,18 @@ class HeroSearchSettingsHelper {
       'text' => $this->config->get($name . '_text'),
       'title' => $this->config->get($name . '_title'),
     ];
+  }
+
+  public function getAlternateSearches() {
+    $search_targets =$this->config->get('search_targets');
+    $alternate_searches = [];
+    foreach ($search_targets as $search_target => $val) {
+      $has_alternate = isset($val['alternate']);
+      if ($has_alternate) {
+        $val['alternate']['search_target'] = $search_target;
+        $alternate_searches[] = $val['alternate'];
+      }
+    }
+    return $alternate_searches;
   }
 }

--- a/web/modules/custom/hero_search/src/Helper/HeroSearchSettingsHelper.php
+++ b/web/modules/custom/hero_search/src/Helper/HeroSearchSettingsHelper.php
@@ -17,14 +17,33 @@ class HeroSearchSettingsHelper {
     'bottom_right_link' => 'Bottom Right Link',
   ];
 
+  /**
+   * The module configuration.
+   *
+   * @var Drupal\Core\Config\ImmutableConfig
+   */
   protected $config;
 
+  /**
+   * The singleton instance.
+   *
+   * @var Drupal\hero_search\Helper\HeroSearchSettingsHelper
+   */
   private static $instance;
 
+  /**
+   * Constructor.
+   */
   private function __construct() {
     $this->config = \Drupal::config('hero_search.settings');
   }
 
+  /**
+   * Returns the single instance of this class.
+   *
+   * @return HeroSearchSettingsHelper
+   *   Tthe singleton instance of this class.
+   */
   public static function getInstance() {
     if (is_null(self::$instance)) {
       self::$instance = new self();
@@ -32,24 +51,61 @@ class HeroSearchSettingsHelper {
     return self::$instance;
   }
 
+  /**
+   * An associative array of search targets.
+   *
+   * @return array
+   *   An associative array of search targets, suitable for use in the "options"
+   *   property of a "radios" form element.
+   */
   public function getSearchTargetOptions() {
     $target_names = array_keys($this->config->get('search_targets'));
     return array_combine($target_names, $target_names);
   }
 
+  /**
+   * Returns the URL for the given search target.
+   *
+   * @param string $target
+   *   The search target to return the URL of.
+   *
+   * @return string
+   *   The URL for the given search target.
+   */
   public function getSearchTargetUrl($target) {
     $targets = $this->config->get('search_targets');
     return $targets[$target]['url'];
   }
 
+  /**
+   * Returns the title to display in the search block.
+   *
+   * @return string
+   *   The title to display in the search block.
+   */
   public function getSearchTitle() {
     return $this->config->get('title');
   }
 
+  /**
+   * Returns the text to display in the search textfield.
+   *
+   * @return string
+   *   The text to display in the search textfield.
+   */
   public function getSearchPlaceholder() {
     return $this->config->get('placeholder');
   }
 
+  /**
+   * Returns an assoc. array of configured link info for the given name or NULL.
+   *
+   * @param string $name
+   *   The name to look up the configured link information.
+   *
+   * @return array
+   *   An associative array of link information for the given name, or NULL.
+   */
   public function getLinkField($name) {
     $url = $this->config->get($name . '_url');
     return $url == NULL ? NULL : [
@@ -59,12 +115,21 @@ class HeroSearchSettingsHelper {
     ];
   }
 
+  /**
+   * Returns a (possibly empty) array of alternate search information.
+   *
+   * @return array
+   *   A (possibly empty) array of associative arrays containing information
+   *   about all alternate search links from the configuration.
+   */
   public function getAlternateSearches() {
     $search_targets = $this->config->get('search_targets');
     $alternate_searches = [];
     foreach ($search_targets as $search_target => $val) {
       $has_alternate = isset($val['alternate']);
       if ($has_alternate) {
+        // Append the search_target to the associative array, so the alternate
+        // can be associated with one of the search options.
         $val['alternate']['search_target'] = $search_target;
         $alternate_searches[] = $val['alternate'];
       }

--- a/web/modules/custom/hero_search/src/Plugin/Block/HeroSearchBlock.php
+++ b/web/modules/custom/hero_search/src/Plugin/Block/HeroSearchBlock.php
@@ -3,7 +3,11 @@
 namespace Drupal\hero_search\Plugin\Block;
 
 use Drupal\Core\Block\BlockBase;
+use Drupal\Core\Form\FormBuilderInterface;
+use Drupal\Core\Plugin\ContainerFactoryPluginInterface;
+use Drupal\Core\Render\RendererInterface;
 use Drupal\hero_search\Helper\HeroSearchSettingsHelper;
+use Symfony\Component\DependencyInjection\ContainerInterface;
 
 /**
  * Implements the HeroSearchBlock.
@@ -14,15 +18,54 @@ use Drupal\hero_search\Helper\HeroSearchSettingsHelper;
  *   category = @Translation("custom"),
  * )
  */
-class HeroSearchBlock extends BlockBase {
+class HeroSearchBlock extends BlockBase implements ContainerFactoryPluginInterface {
+
+  protected $formBuilder;
+  protected $renderer;
+
+  /**
+   * @param array $configuration
+   * @param string $plugin_id
+   * @param mixed $plugin_definition
+   * @param \Drupal\Core\Form\FormBuilderInterface $formBuilder
+   * @param \Drupal\Core\Render\RendererInterface $renderer
+   */
+  public function __construct(
+      array $configuration,
+      $plugin_id,
+      $plugin_definition,
+      FormBuilderInterface $formBuilder,
+      RendererInterface $renderer) {
+    parent::__construct($configuration, $plugin_id, $plugin_definition);
+    $this->formBuilder = $formBuilder;
+    $this->renderer = $renderer;
+  }
+
+  /**
+   * @param \Symfony\Component\DependencyInjection\ContainerInterface $container
+   * @param array $configuration
+   * @param string $plugin_id
+   * @param mixed $plugin_definition
+   *
+   * @return static
+   */
+  public static function create(ContainerInterface $container, array $configuration, $plugin_id, $plugin_definition) {
+    return new static(
+      $configuration,
+      $plugin_id,
+      $plugin_definition,
+      $container->get('form_builder'),
+      $container->get('renderer')
+    );
+  }
 
   /**
    * {@inheritdoc}
    */
   public function build() {
     $configHelper = HeroSearchSettingsHelper::getInstance();
-    $form = \Drupal::formBuilder()->getForm('Drupal\hero_search\Form\HeroSearchForm');
-    $rendered_form = \Drupal::service('renderer')->render($form);
+    $form = $this->formBuilder->getForm('Drupal\hero_search\Form\HeroSearchForm');
+    $rendered_form = $this->renderer->render($form);
     $buttons = array_filter([
       $configHelper->getLinkField('button1'),
       $configHelper->getLinkField('button2'),

--- a/web/modules/custom/hero_search/src/Plugin/Block/HeroSearchBlock.php
+++ b/web/modules/custom/hero_search/src/Plugin/Block/HeroSearchBlock.php
@@ -1,8 +1,4 @@
 <?php
-/**
- * @file
- * Definition of Drupal\hero_search\Plugin\Block\HeroSearchBlock
- */
 
 namespace Drupal\hero_search\Plugin\Block;
 
@@ -10,8 +6,8 @@ use Drupal\Core\Block\BlockBase;
 use Drupal\hero_search\Helper\HeroSearchSettingsHelper;
 
 /**
- * Implements the HeroSearchBlock
- * 
+ * Implements the HeroSearchBlock.
+ *
  * @Block(
  *   id = "hero_search",
  *   admin_label = @Translation("Hero Search"),
@@ -47,4 +43,5 @@ class HeroSearchBlock extends BlockBase {
       '#hero_search_bottom_right_link' => $bottom_right_link,
     ];
   }
+
 }

--- a/web/modules/custom/hero_search/src/Plugin/Block/HeroSearchBlock.php
+++ b/web/modules/custom/hero_search/src/Plugin/Block/HeroSearchBlock.php
@@ -20,15 +20,33 @@ use Symfony\Component\DependencyInjection\ContainerInterface;
  */
 class HeroSearchBlock extends BlockBase implements ContainerFactoryPluginInterface {
 
+  /**
+   * Form builder service.
+   *
+   * @var Drupal\Core\Plugin\ContainerFactoryPluginInterface
+   */
   protected $formBuilder;
+
+  /**
+   * Renderer service.
+   *
+   * @var Drupal\Core\Plugin\ContainerFactoryPluginInterface
+   */
   protected $renderer;
 
   /**
+   * Constructor.
+   *
    * @param array $configuration
+   *   Configuration array containing information about the plugin instance.
    * @param string $plugin_id
+   *   The id for the plugin.
    * @param mixed $plugin_definition
-   * @param \Drupal\Core\Form\FormBuilderInterface $formBuilder
-   * @param \Drupal\Core\Render\RendererInterface $renderer
+   *   The definition of the plugin implementaton.
+   * @param Drupal\Core\Form\FormBuilderInterface $formBuilder
+   *   The "form_builder" service instance to use.
+   * @param Drupal\Core\Render\RendererInterface $renderer
+   *   The "renderer" service instance to use.
    */
   public function __construct(
       array $configuration,
@@ -42,12 +60,7 @@ class HeroSearchBlock extends BlockBase implements ContainerFactoryPluginInterfa
   }
 
   /**
-   * @param \Symfony\Component\DependencyInjection\ContainerInterface $container
-   * @param array $configuration
-   * @param string $plugin_id
-   * @param mixed $plugin_definition
-   *
-   * @return static
+   * {@inheritdoc}
    */
   public static function create(ContainerInterface $container, array $configuration, $plugin_id, $plugin_definition) {
     return new static(

--- a/web/modules/custom/hero_search/templates/hero-search-form.html.twig
+++ b/web/modules/custom/hero_search/templates/hero-search-form.html.twig
@@ -1,7 +1,7 @@
 {{ form.form_build_id }}
 {{ form.form_token }}
 {{ form.form_id }}
- 
+
 <div class="hero-search-form">
   <div class="row hero-search-input">
     {{ form.search_query }}
@@ -10,7 +10,7 @@
   <div class="row hero-search-options">
     {{ form.search_target }}
     <span class='hero-search-left-align darklinks'>
-      {{ form.advanced_search }}
+      {{ form.alternate_search }}
     </span>
   </div>
 </div>


### PR DESCRIPTION
Modified the "Hero Search" block to only display the "Advanced Search"
when the "WorldCat" radio button is selected.

Modified the "Hero Search" configuration so that search targets can
be specified using a YAML format. Then provided support for an
"alternate" setting, so that any search target could specify an
alternative search link that would be displaye (when that
search target was selected).

Added an update hook to modify the configuration so that
the "Advanced Search" alternate search would be used by
the "WorldCat" search target.

Moved the "Hero Search" configuration from the "Configuration"
main page to be a tab in the "Libraries' Configuration"  page.

Fixed various "phpcs" warnings and added PHP doc comments.

https://issues.umd.edu/browse/LIBWEB-5441