### PR TITLE
LIBWEB-5449. Modified Equipment Tracking to support multiple bibnums

### DIFF
--- a/web/modules/custom/aleph_connector/modules/equipment_tracking/src/Plugin/views/field/EquipmentAvailability.php
+++ b/web/modules/custom/aleph_connector/modules/equipment_tracking/src/Plugin/views/field/EquipmentAvailability.php
@@ -8,7 +8,6 @@
 namespace Drupal\equipment_tracking\Plugin\views\field;
 
 use Drupal\Core\Form\FormStateInterface;
-use Drupal\node\Entity\NodeType;
 use Drupal\views\Plugin\views\field\FieldPluginBase;
 use Drupal\views\ResultRow;
 use Drupal\aleph_connector\Controller\AlephController;
@@ -60,41 +59,61 @@ class EquipmentAvailability extends FieldPluginBase {
   public function render(ResultRow $values) {
     $bibnums = [];
     $aleph = new AlephController();
+
     if (!$this->isValueEmpty($aleph->getQueryField(), TRUE)) {
-      if ($bibnum = $this->view->field[$aleph->getQueryField()]->original_value->__toString()) {
-        $bibnums[] = $bibnum;
+      $field = $this->view->field[$aleph->getQueryField()];
+      if ($field instanceof \Drupal\search_api\Plugin\views\field\SearchApiEntityField) {
+        $items = $field->getItems($values);
+        foreach ($items as $item) {
+          $bibnum = $item['value'];
+          $bibnums[] = $bibnum;
+        }
       }
     }
+
     if (count($bibnums) > 0) {
       if ($bibnum_data = $aleph->getBibnumData($bibnums)) {
         return $this->availabilityField($bibnums, $bibnum_data);
       }
     }
-    return FALSE; 
+    return FALSE;
   }
 
   /**
    * Generate sample page content for umd-examples page.
    */
   public function availabilityField($bibnums, $availability_data) {
-    $availability_data = reset($availability_data);
-    $processed_date = null;
-    if ($raw_date = $availability_data['mindue']) {
-      try {
-        // 2021-07-30-16:30
-        $datetime_p = DateTimePlus::createFromFormat('YmdHi', $raw_date);
-        $processed_date = $datetime_p->format('g:i A \o\n F j, Y');
-      }
-      catch (\InvalidArgumentException $e) {
-        // TODO: Replace this with logger -- \Drupal::messenger()->addError('Error 1: ' . $e->getMessage());
-      }
-      catch (\UnexpectedValueException $e) {
-        // TODO: Replace this with logger -- \Drupal::messenger()->addError('Error 2: ' . $e->getMessage());
+    $available_count = 0;
+
+    $earliest_raw_date = null;
+    $processed_date = NULL;
+
+    foreach ($availability_data as $datum) {
+      $available_count += $datum['available'];
+
+      if ($raw_date = $datum['mindue']) {
+        if (!$earliest_raw_date || ($raw_date < $earliest_raw_date)) {
+          $earliest_raw_date = $raw_date;
+          try {
+            // 2021-07-30-16:30
+            $datetime_p = DateTimePlus::createFromFormat('YmdHi', $raw_date);
+            $processed_date = $datetime_p->format('g:i A \o\n F j, Y');
+          }
+          catch (\InvalidArgumentException $e) {
+            // TODO: Replace this with logger -- \Drupal::messenger()->addError('Error 1: ' . $e->getMessage());
+            dpm($e);
+          }
+          catch (\UnexpectedValueException $e) {
+            // TODO: Replace this with logger -- \Drupal::messenger()->addError('Error 2: ' . $e->getMessage());
+            dpm($e);
+          }
+        }
       }
     }
+
     return [
       '#theme' => 'aleph_equipment_available',
-      '#equipment_count' => $availability_data['available'],
+      '#equipment_count' => $available_count,
       '#equipment_mindue' => $processed_date,
       '#equipment_sysnum' => implode(',', $bibnums),
     ];

--- a/web/modules/custom/aleph_connector/modules/equipment_tracking/src/Plugin/views/field/EquipmentAvailability.php
+++ b/web/modules/custom/aleph_connector/modules/equipment_tracking/src/Plugin/views/field/EquipmentAvailability.php
@@ -1,22 +1,17 @@
 <?php
 
-/**
- * @file
- * Definition of Drupal\equipment_tracking\Plugin\views\field\EquipmentAvailability
- */
-
 namespace Drupal\equipment_tracking\Plugin\views\field;
 
-use Drupal\Core\Form\FormStateInterface;
+use Drupal\Core\Logger\LoggerChannelInterface;
+use Drupal\aleph_connector\Controller\AlephController;
 use Drupal\views\Plugin\views\field\FieldPluginBase;
 use Drupal\views\ResultRow;
-use Drupal\aleph_connector\Controller\AlephController;
+use Drupal\search_api\Plugin\views\field\SearchApiEntityField;
 use Drupal\Component\Datetime\DateTimePlus;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 
-
 /**
- * Field handler to flag the node type.
+ * Field handler for equipment availibility.
  *
  * @ingroup views_field_handlers
  *
@@ -32,7 +27,7 @@ class EquipmentAvailability extends FieldPluginBase {
   protected $logger;
 
   /**
-   * Constructs a PluginBase object.
+   * Constructs an EquipmentAvailability object.
    *
    * @param array $configuration
    *   A configuration array containing information about the plugin instance.
@@ -43,7 +38,7 @@ class EquipmentAvailability extends FieldPluginBase {
    * @param \Drupal\Core\Logger\LoggerChannelInterface $logger
    *   The logger instance.
    */
-  public function __construct(array $configuration, $plugin_id, $plugin_definition, $logger) {
+  public function __construct(array $configuration, $plugin_id, $plugin_definition, LoggerChannelInterface $logger) {
     parent::__construct($configuration, $plugin_id, $plugin_definition);
 
     $this->definition = $plugin_definition + $configuration;
@@ -64,38 +59,14 @@ class EquipmentAvailability extends FieldPluginBase {
   }
 
   /**
-   * @{inheritdoc}
+   * {@inheritdoc}
    */
   public function query() {
     // Leave empty to avoid a query on this field.
   }
 
   /**
-   * Define the available options
-   * @return array
-   */
-  protected function defineOptions() {
-    $options = parent::defineOptions();
-    return $options;
-  }
-
-  /**
-   * Provide the options form.
-   *
-   * @note
-   *   More investigation needed to determine how to actually use these options.
-   */
-  public function buildOptionsForm(&$form, FormStateInterface $form_state) {
-    $form['unused'] = array(
-      '#title' => $this->t('Unused'),
-      '#description' => $this->t('A description can go here.'),
-      '#type' => 'textfield',
-    );
-    parent::buildOptionsForm($form, $form_state);
-  }
-
-  /**
-   * @{inheritdoc}
+   * {@inheritdoc}
    */
   public function render(ResultRow $values) {
     $bibnums = [];
@@ -103,7 +74,7 @@ class EquipmentAvailability extends FieldPluginBase {
 
     if (!$this->isValueEmpty($aleph->getQueryField(), TRUE)) {
       $field = $this->view->field[$aleph->getQueryField()];
-      if ($field instanceof \Drupal\search_api\Plugin\views\field\SearchApiEntityField) {
+      if ($field instanceof SearchApiEntityField) {
         $items = $field->getItems($values);
         foreach ($items as $item) {
           $bibnum = $item['value'];
@@ -125,7 +96,7 @@ class EquipmentAvailability extends FieldPluginBase {
    */
   public function availabilityField($bibnums, $availability_data) {
     $available_count = 0;
-    $earliest_raw_date = null;
+    $earliest_raw_date = NULL;
     $processed_date = NULL;
 
     foreach ($availability_data as $datum) {
@@ -157,4 +128,5 @@ class EquipmentAvailability extends FieldPluginBase {
       '#equipment_sysnum' => implode(',', $bibnums),
     ];
   }
+
 }

--- a/web/modules/custom/aleph_connector/modules/equipment_tracking/src/Plugin/views/field/EquipmentAvailability.php
+++ b/web/modules/custom/aleph_connector/modules/equipment_tracking/src/Plugin/views/field/EquipmentAvailability.php
@@ -12,6 +12,8 @@ use Drupal\views\Plugin\views\field\FieldPluginBase;
 use Drupal\views\ResultRow;
 use Drupal\aleph_connector\Controller\AlephController;
 use Drupal\Component\Datetime\DateTimePlus;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+
 
 /**
  * Field handler to flag the node type.
@@ -21,6 +23,45 @@ use Drupal\Component\Datetime\DateTimePlus;
  * @ViewsField("aleph_equipment_available")
  */
 class EquipmentAvailability extends FieldPluginBase {
+
+  /**
+   * The logger instance.
+   *
+   * @var Drupal\Core\Logger\LoggerChannelInterface
+   */
+  protected $logger;
+
+  /**
+   * Constructs a PluginBase object.
+   *
+   * @param array $configuration
+   *   A configuration array containing information about the plugin instance.
+   * @param string $plugin_id
+   *   The plugin_id for the plugin instance.
+   * @param mixed $plugin_definition
+   *   The plugin implementation definition.
+   * @param \Drupal\Core\Logger\LoggerChannelInterface $logger
+   *   The logger instance.
+   */
+  public function __construct(array $configuration, $plugin_id, $plugin_definition, $logger) {
+    parent::__construct($configuration, $plugin_id, $plugin_definition);
+
+    $this->definition = $plugin_definition + $configuration;
+    $this->logger = $logger;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function create(ContainerInterface $container, array $configuration, $plugin_id, $plugin_definition) {
+    return new static(
+      $configuration,
+      $plugin_id,
+      $plugin_definition,
+      // Inject a logger instance.
+      $container->get('logger.factory')->get('equipment_availability')
+    );
+  }
 
   /**
    * @{inheritdoc}
@@ -84,28 +125,26 @@ class EquipmentAvailability extends FieldPluginBase {
    */
   public function availabilityField($bibnums, $availability_data) {
     $available_count = 0;
-
     $earliest_raw_date = null;
     $processed_date = NULL;
 
     foreach ($availability_data as $datum) {
       $available_count += $datum['available'];
 
-      if ($raw_date = $datum['mindue']) {
+      if ($raw_date = ($datum['mindue'])) {
         if (!$earliest_raw_date || ($raw_date < $earliest_raw_date)) {
           $earliest_raw_date = $raw_date;
           try {
-            // 2021-07-30-16:30
+            // Expected raw_data format: 202107301630
+            // (i.e. 16:30 on July 30, 2021)
             $datetime_p = DateTimePlus::createFromFormat('YmdHi', $raw_date);
             $processed_date = $datetime_p->format('g:i A \o\n F j, Y');
           }
           catch (\InvalidArgumentException $e) {
-            // TODO: Replace this with logger -- \Drupal::messenger()->addError('Error 1: ' . $e->getMessage());
-            dpm($e);
+            $this->logger->error("InvalidArgumentException: Error parsing date: '$raw_date'.");
           }
           catch (\UnexpectedValueException $e) {
-            // TODO: Replace this with logger -- \Drupal::messenger()->addError('Error 2: ' . $e->getMessage());
-            dpm($e);
+            $this->logger->error("UnexpectedValueException: Error parsing date: '$raw_date'.", $e);
           }
         }
       }

--- a/web/modules/custom/umd_libraries_hours/umd_libraries_hours.views_execution.inc
+++ b/web/modules/custom/umd_libraries_hours/umd_libraries_hours.views_execution.inc
@@ -4,8 +4,8 @@
 * Implements hook_views_query_alter().
 */
 
-function umd_libraries_hours_views_query_alter(\Drupal\views\ViewExecutable $view, \Drupal\views\Plugin\views\query\Sql $query) {
-  if ($view->id() == 'hours_today') {
+function umd_libraries_hours_views_query_alter(\Drupal\views\ViewExecutable $view, \Drupal\views\Plugin\views\query\QueryPluginBase $query) {
+  if ($view->id() == 'hours_today' && ($query instanceof \Drupal\views\Plugin\views\query\Sql)) {
     $start = strtotime('today 00:10');
     $end = strtotime('tomorrow 00:10');
     $query->where[] = array(


### PR DESCRIPTION
Modified the "EquipmentAvailability" in "web/modules/custom/aleph_connector/modules/equipment_tracking/src/Plugin/views/field/EquipmentAvailability.php" to retrieve multiple bibnums from the "SearchApiEntityField" field passed into the view, and modified the count to sum up the count for each bibnum. Also added code to find the earliest timestamp for the "mindue" field for the bibnums, to find the earliest due date (which is shown if no items are available).

Modified "web/modules/custom/umd_libraries_hours/umd_libraries_hours.views_execution.inc" to fix a TypeError.

https://issues.umd.edu/browse/LIBWEB-5449