### PR TITLE
LIBWEB-5457. Added hero search target-configurable placeholder text

### DIFF
--- a/web/modules/custom/hero_search/README.md
+++ b/web/modules/custom/hero_search/README.md
@@ -28,6 +28,7 @@ The YAML format is the following:
 <SEARCH_TARGET_NAME>:
   url: '<URL>'
   alternate: { url: '<ALTERNATE_URL>', text: 'ALTERNATE_LINK_TEXT', title: 'ALTERNATE_TOOLTIP_TEXT' }
+  placeholder: '<PLACEHOLDER_TEXT>'
 ```
 
 where:
@@ -40,19 +41,27 @@ where:
     to a vendor search page.
 * ALTERNATE_LINK_TEXT - The text to display for the link
 * ALTERNATE_TOOLTIP_TEXT - The tooltip to display when hovering over the link.
+* PLACEHOLDER_TEXT - The placeholder text to display in the search textfield
 
 Sample configuration:
 
 ```
 All:
     url: 'https://searchnew.lib.umd.edu/results?search&query='
+    placeholder: 'Find books, journals, articles, media & more'
 'UMD Catalog':
     url: 'https://catalog.umd.edu/cgi-bin/direct?searchtype=F1_WRD&base=CP&search=&searchrequest='
+    placeholder: 'Search for items held at UMD'
 WorldCat:
     url: 'https://umaryland.on.worldcat.org/search?databaseList=&umdlib=&queryString='
     alternate: { url: 'https://umaryland.on.worldcat.org/advancedsearch', text: 'Advanced Search', title: tooltip }
+    placeholder: 'Search books, articles, journals, and website'
 ```
 
 Provides three search option, "All", "UMD Catalog", and "WorldCat".
+
 When the "WorldCat" option is selected in the GUI, the "alternate" link will
 also be displayed.
+
+The "placeholder" value is optional -- if not provided, default placeholder text
+will be used.

--- a/web/modules/custom/hero_search/hero_search.install
+++ b/web/modules/custom/hero_search/hero_search.install
@@ -23,7 +23,7 @@ function hero_search_update_8002() {
   $hero_search_settings->set('search_targets',
       [
         "All" => [
-          "url" => "https://foobar.lib.umd.edu/results?search&query=",
+          "url" => "https://searchnew.lib.umd.edu/results?search&query=",
         ],
         "UMD Catalog" => [
           "url" => "https://catalog.umd.edu/cgi-bin/direct?searchtype=F1_WRD&base=CP&search=&searchrequest=",
@@ -44,4 +44,37 @@ function hero_search_update_8002() {
   $hero_search_settings->clear('advanced_search_text');
   $hero_search_settings->clear('advanced_search_title');
   $hero_search_settings->save();
+}
+
+/**
+ * LIBWEB-5457 - Replace "placeholder" key with "default_placeholder" key.
+ *
+ * Also configures placeholders for known search targets.
+ */
+function hero_search_update_8003() {
+  $config_factory = \Drupal::configFactory();
+  $hero_search_settings = $config_factory->getEditable('hero_search.settings');
+  $current_placeholder = $hero_search_settings->get('placeholder');
+  $hero_search_settings->set('default_placeholder', $current_placeholder);
+  $hero_search_settings->clear('placeholder');
+
+  // Added "placeholder" setting to individual search targets.
+  $placeholders = [
+    'All' => 'Find books, journals, articles, media & more',
+    'UMD Catalog' => 'Search for items held at UMD',
+    'WorldCat' => 'Search books, articles, journals, and website',
+  ];
+
+  $search_targets = $hero_search_settings->get('search_targets');
+  if ($search_targets) {
+    foreach ($search_targets as $key => $values) {
+      $placeholder = $placeholders[$key];
+      if (isset($placeholder) && !isset($values['placeholder'])) {
+        $search_targets[$key]['placeholder'] = $placeholder;
+      }
+    }
+    $hero_search_settings->set('search_targets', $search_targets);
+  }
+
+  $hero_search_settings->save(TRUE);
 }

--- a/web/modules/custom/hero_search/src/Form/HeroSearchSettingsForm.php
+++ b/web/modules/custom/hero_search/src/Form/HeroSearchSettingsForm.php
@@ -93,8 +93,8 @@ class HeroSearchSettingsForm extends ConfigFormBase {
 
     $form['placeholder'] = [
       '#type' => 'textfield',
-      '#title' => $this->t('Placeholder'),
-      '#default_value' => $config->get('placeholder'),
+      '#title' => $this->t('Default Placeholder'),
+      '#default_value' => $config->get('default_placeholder'),
       '#size' => 50,
       '#maxlength' => 60,
       '#required' => TRUE,

--- a/web/modules/custom/hero_search/src/Helper/HeroSearchSettingsHelper.php
+++ b/web/modules/custom/hero_search/src/Helper/HeroSearchSettingsHelper.php
@@ -52,11 +52,27 @@ class HeroSearchSettingsHelper {
   }
 
   /**
-   * An associative array of search targets.
+   * An associative array of configuration information for search targets.
    *
    * @return array
-   *   An associative array of search targets, suitable for use in the "options"
-   *   property of a "radios" form element.
+   *   An associative array of configuration information for search targets.
+   */
+  public function getSearchTargets() {
+    $search_targets = $this->config->get('search_targets');
+    foreach ($search_targets as $search_target => &$val) {
+      // Append the search_target to the associative array, so that the
+      // configuration can be associated with one of the search options.
+      $val['search_target'] = $search_target;
+    }
+    return $search_targets;
+  }
+
+  /**
+   * An associative array of search target names.
+   *
+   * @return array
+   *   An associative array of search target names, suitable for use in the
+   *   "options" property of a "radios" form element.
    */
   public function getSearchTargetOptions() {
     $target_names = array_keys($this->config->get('search_targets'));
@@ -88,13 +104,13 @@ class HeroSearchSettingsHelper {
   }
 
   /**
-   * Returns the text to display in the search textfield.
+   * Returns the default placeholder text to display in the search textfield.
    *
    * @return string
-   *   The text to display in the search textfield.
+   *   The default placeholder text to display in the search textfield.
    */
-  public function getSearchPlaceholder() {
-    return $this->config->get('placeholder');
+  public function getDefaultSearchPlaceholder() {
+    return $this->config->get('default_placeholder');
   }
 
   /**


### PR DESCRIPTION
Modified the Hero search so that individual placeholder text can be
provided for search targets. Was implemented using the Drupal
"Conditional Form Fields" functionality, but creating individual
textfields for each search target, and then enabling only the relevant
textfield (based on the selected radio button).

Added handling for an (optional) "placeholder" key in the YAML
configuration for the search targets.

Changed the existing "Placeholder" configuration field with
"Default Placeholder", which will be used if no "placeholder" value is
provided from a search target.

Added a "hook_update" to "hero_search.install" to update an existing
configuration, replacing the "placeholder" field with
"default_placeholder" and configuring "placeholder" values for the
search targets.

https://issues.umd.edu/browse/LIBWEB-5457