### PR TITLE
LIBWEB-5491 Mobile display: fix Collections area

### DIFF
--- a/web/modules/custom/hero_search/css/hero-search.css
+++ b/web/modules/custom/hero_search/css/hero-search.css
@@ -104,7 +104,13 @@ textarea {
     right: 1rem;
   }
 }
-
+@media (max-width: 799px) {
+  .card-wrap {
+    flex: auto!important;
+    max-width: 100%!important;
+    padding-left: 0!important;
+  }
+}
 @media (max-width: 768px) {
   .hero-block {
     margin-left: 0!important;


### PR DESCRIPTION
- Changed mobile display: when max-width smaller than 800 (=<799px), the collection area on homepage will becomes one column instead of two.
https://issues.umd.edu/browse/LIBWEB-5491